### PR TITLE
ADD: basic configparser using regexes to load args from file.

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -621,7 +621,7 @@ class FileArgumentParser(argparse.ArgumentParser):
         for location in self.CONFIG_FILE_LOCATIONS:
             if os.path.exists(location):
                 import pdb; pdb.set_trace()
-                return super().parse_args([f'@{location}', *args])
+                return super().parse_args(['@'+location, *args])
         return super().parse_args(args)
 
     def convert_arg_line_to_args(self, arg_line):

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1418,6 +1418,42 @@ Print my path and return error code
             self.assertEqual(stderr.getvalue().strip(), filename,
                              msg='Changed file should be reported')
 
+    def test_file_argument_parser(self):
+        with temporary_file('''
+[flake8]
+in-place = true
+check = true
+
+[docformatter]
+#help = true
+#in-place = true
+check = true
+#recursive = true
+#wrap-summaries = 79
+#wrap-descriptions = 72
+#blank = true
+#pre-summary-newline = true
+#make-summary-multi-line = true
+#force-wrap = true
+#range = 1,33
+#version = true
+
+[pylint]
+in-place = true
+check = true
+''') as config, temporary_file('asdf') as dummy:
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            ret_code = docformatter._main(
+                argv=['my_fake_program', '@'+config, dummy],
+                standard_out=stdout, standard_error=stderr, standard_in=None
+            )
+            self.assertIn(stdout.getvalue(), 'show this help message and exit',
+                             msg='Only write help to stdout')
+            self.assertEqual(stderr.getvalue(), '',
+                             msg='Do not write to stderr')
+            self.assertEqual(ret_code, 0,
+                             msg='Exit code should be 0')  # FormatResult.ok
 
 def generate_random_docstring(max_indentation_length=32,
                               max_word_length=20,


### PR DESCRIPTION
A new class is added (FileArgumentParser), which:

1. Allows cmdline args starting with '@' to locate a file used to
load additional commandline args (this is standard ArgumentParser).

2. Extend the 'convert_arg_line_to_args' method to parse ini-like
lines from said file. It also replaces lines like 'value = true'
with its cmdline equivalent: '--value'

3. Attempt to load files located at:
* docformatterrc
* docformatter.ini
* docformatter.cfg
* tox.ini