### PR TITLE
Always put quotes on a new line unless everything fits on one line

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -233,10 +233,21 @@ def format_docstring(indentation, docstring,
                 ending=ending
             )
         else:
-            return wrap_summary('"""' + normalize_summary(contents) + '"""',
-                                wrap_length=summary_wrap_length,
-                                initial_indent=indentation,
-                                subsequent_indent=indentation).strip()
+            summary_wrapped = wrap_summary(
+                '"""' + normalize_summary(contents),
+                wrap_length=summary_wrap_length,
+                initial_indent=indentation,
+                subsequent_indent=indentation)
+
+            summary_is_one_line = '\n' not in summary_wrapped
+            quotes_fit_on_line = len(indentation) + len(summary_wrapped) + 3 <= summary_wrap_length
+            if not summary_wrap_length or (summary_is_one_line and quotes_fit_on_line):
+                ending = '"""'
+            else:
+                ending = '\n' + indentation + '"""'
+            return '{summary}{ending}'.format(
+                summary=summary_wrapped,
+                ending=ending)
 
 
 def reindent(text, indentation):

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -1141,13 +1141,14 @@ Args:
         self.assertEqual(('''\
 """num_iterations is the number of updates -
     instead of a better definition of
-    convergence."""\
+    convergence.
+    """\
 '''),
                          docformatter.format_docstring('    ', '''\
 """
 num_iterations is the number of updates - instead of a better definition of convergence.
 """\
-''', description_wrap_length=50, summary_wrap_length=50, force_wrap=True))
+''', description_wrap_length=49, summary_wrap_length=49, force_wrap=True))
 
     def test_remove_section_header(self):
         self.assertEqual(
@@ -1182,6 +1183,24 @@ num_iterations is the number of updates - instead of a better definition of conv
 """This one-line docstring will be multi-line"""\
 ''', make_summary_multi_line=True))
 
+    def test_format_docstring_for_multi_line_summary_alone(self):
+        self.assertEqual(('''\
+"""This one-line docstring will be multi-line because it's quite
+    long.
+    """\
+'''),
+                         docformatter.format_docstring('    ', '''\
+"""This one-line docstring will be multi-line because it's quite long."""\
+''', summary_wrap_length=69))
+
+    def test_format_docstring_for_one_line_summary_alone_but_too_long(self):
+        self.assertEqual(('''\
+"""This one-line docstring will not be multi-line but quotes will be below.
+    """\
+'''),
+                         docformatter.format_docstring('    ', '''\
+"""This one-line docstring will not be multi-line but quotes will be below."""\
+''', summary_wrap_length=80))
 
 class TestSystem(unittest.TestCase):
 
@@ -1282,13 +1301,13 @@ def foo():
             process = run_docformatter(['--wrap-summaries=40',
                                         filename])
             self.assertEqual('''\
-@@ -1,4 +1,3 @@
+@@ -1,4 +1,4 @@
  def foo():
--    """
++    """Hello world this is a summary
++    that will get wrapped.
+     """
 -    Hello world this is a summary that will get wrapped
 -    """
-+    """Hello world this is a summary
-+    that will get wrapped."""
 ''', '\n'.join(process.communicate()[0].decode().split('\n')[2:]))
 
     def test_end_to_end_with_no_wrapping(self):


### PR DESCRIPTION
Fixes #9.

I added tests and had to update a few other tests as well.

This formatting is coherent with your documentation:
> Unless the entire docstring fits on a line, place the closing quotes on a line by themselves.