### PR TITLE
Add pyproject.toml support for config (Issue #10)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,12 +167,27 @@ Below is the help output::
       --range line line     apply docformatter to docstrings between these lines;
                             line numbers are indexed at 1
       --version             show program's version number and exit
+      --config CONFIG       path to file containing docformatter options
 
 
 Possible exit codes:
 
 - **1** - if any error encountered
 - **3** - if any file needs to be formatted (in ``--check`` mode)
+
+docformatter options can also be stored in a configuration file.  Currently only
+pyproject.toml is supported.  Add section [tool.docformatter] with options listed using
+the same name as command line options.  For example::
+
+      [tool.docformatter]
+      recursive = true
+      wrap-summaries = 82
+      blank = true
+
+Command line options take precedence.  The configuration file can be passed with a full
+path, otherwise docformatter will look in the current directory.  For example::
+
+      docformatter --config ~/.secret/path/to/pyproject.toml
 
 Wrapping descriptions
 =====================


### PR DESCRIPTION
I submit for your consideration a potential solution to issue #10 .

This adds two functions:
* One to find the config file specified with the new --config option and compare it against a list of supported config files (currently only pyproject.toml).
* A second function to read the contents of the config file into a dict which is returned to _main().

The dict is used to set default values in the add_argument() methods, thus ensuring command line options take precedence.  Adding additional config files (e.g., setup.cfg, tox.ini) should be reasonably trivial with these functions.

Four tests have been added to the test suite to test these two functions and a section added to the README to explain the use of pyproject.toml.  All tests pass as well as all static checks.  I've been successfully using my fork for my use cases; command line, key-mapped in IDE, pre-commit and GH actions.

Closes #10