### PR TITLE
fix: add support for raw and unicode docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ mock = "^4.0.0"
 isort = "^5.7.0"
 black = [
     {version = "^22.0.0", python = ">=3.6.2"},
-    ]
+]
 
 [tool.poetry.scripts]
 docformatter = "docformatter:main"
@@ -180,7 +180,6 @@ deps =
     pylint
     toml
 commands =
-    pip install .[tomli]
     pycodestyle docformatter.py setup.py
     pydocstyle docformatter.py setup.py
     pylint docformatter.py setup.py

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup
 
 def version():
     """Return version string."""
-    with open('docformatter.py') as input_file:
+    with open('docformatter.py', encoding="ascii") as input_file:
         for line in input_file:
             if line.startswith('__version__'):
                 return ast.parse(line).body[0].value.s
@@ -24,7 +24,7 @@ def version():
 setup(name='docformatter',
       version=version(),
       description='Formats docstrings to follow PEP 257.',
-      long_description=Path('README.rst').read_text(),
+      long_description=Path('README.rst').read_text(encoding="ascii"),
       license='Expat License',
       author='Steven Myint',
       url='https://github.com/myint/docformatter',

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -578,14 +578,16 @@ def foo():
     def test_method_no_chr_92(): the501(92) # \
 '''.lstrip()))
 
-    def test_format_code_skip_complex(self):
-        """We do not handle r/u/b prefixed strings."""
+    def test_format_code_raw_docstring_double_quotes(self):
+        """Should format raw docstrings with triple double quotes.
+
+        See requirement #2.  See issue #54 for request to handle raw
+        docstrings.
+        """
         self.assertEqual(
             '''\
 def foo():
-    r"""
-    Hello foo.
-    """
+    r"""Hello foo."""
 ''',
             docformatter.format_code(
                 '''\
@@ -595,19 +597,111 @@ def foo():
     """
 '''))
 
-    def test_format_code_skip_complex_single(self):
-        """We do not handle r/u/b prefixed strings."""
         self.assertEqual(
-            """\
+        '''\
 def foo():
-    r'''
+    R"""Hello foo."""
+''',
+            docformatter.format_code(
+            '''\
+def foo():
+    R"""
     Hello foo.
-    '''
-""",
+    """
+'''))
+
+    def test_format_code_raw_docstring_single_quotes(self):
+        """Should format raw docstrings with triple single quotes.
+
+        See requirement #2.  See issue #54 for request to handle raw
+        docstrings.
+        """
+        self.assertEqual(
+            '''\
+def foo():
+    r"""Hello foo."""
+''',
             docformatter.format_code(
                 """\
 def foo():
     r'''
+    Hello foo.
+    '''
+"""))
+
+        self.assertEqual(
+        '''\
+def foo():
+    R"""Hello foo."""
+''',
+           docformatter.format_code(
+            """\
+def foo():
+    R'''
+    Hello foo.
+    '''
+"""))
+
+    def test_format_code_unicode_docstring_double_quotes(self):
+        """Should format unicode docstrings with triple double quotes.
+
+        See requirement #3.  See issue #54 for request to handle raw
+        docstrings.
+        """
+        self.assertEqual(
+            '''\
+def foo():
+    u"""Hello foo."""
+''',
+            docformatter.format_code(
+                '''\
+def foo():
+    u"""
+    Hello foo.
+    """
+'''))
+
+        self.assertEqual(
+            '''\
+def foo():
+    U"""Hello foo."""
+''',
+            docformatter.format_code(
+                '''\
+def foo():
+    U"""
+    Hello foo.
+    """
+'''))
+
+    def test_format_code_unicode_docstring_single_quotes(self):
+        """Should format unicode docstrings with triple single quotes.
+
+        See requirement #3.  See issue #54 for request to handle raw
+        docstrings.
+        """
+        self.assertEqual(
+            '''\
+def foo():
+    u"""Hello foo."""
+''',
+            docformatter.format_code(
+                """\
+def foo():
+    u'''
+    Hello foo.
+    '''
+"""))
+
+        self.assertEqual(
+            '''\
+def foo():
+    U"""Hello foo."""
+''',
+            docformatter.format_code(
+                """\
+def foo():
+    U'''
     Hello foo.
     '''
 """))

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -150,7 +150,6 @@ The below should be indented with spaces:
         )
 
 
-
 class TestNormalizers:
     """Class for testing the string normalizing functions.
 
@@ -452,7 +451,7 @@ class TestStrippers:
     @pytest.mark.unit
     def test_strip_docstring(self):
         """Strip triple double quotes from docstring."""
-        assert "Hello." == docformatter.strip_docstring(
+        docstring, open_quote = docformatter.strip_docstring(
             '''
     """Hello.
 
@@ -460,11 +459,13 @@ class TestStrippers:
 
     '''
         )
+        assert docstring == "Hello."
+        assert open_quote == '"""'
 
     @pytest.mark.unit
     def test_strip_docstring_with_single_quotes(self):
         """Strip triple single quotes from docstring."""
-        assert "Hello." == docformatter.strip_docstring(
+        docstring, open_quote == docformatter.strip_docstring(
             """
     '''Hello.
 
@@ -472,17 +473,37 @@ class TestStrippers:
 
     """
         )
+        assert docstring == "Hello."
+        assert open_quote == '"""'
 
     @pytest.mark.unit
     def test_strip_docstring_with_empty_string(self):
         """Return series of six double quotes when passed empty string."""
-        assert "" == docformatter.strip_docstring('""""""')
+        docstring, open_quote = docformatter.strip_docstring('""""""')
+        assert docstring == ""
+        assert open_quote == '"""'
 
     @pytest.mark.unit
-    def test_strip_docstring_with_unhandled(self):
-        """Raise ValueError with raw docstrings."""
-        with pytest.raises(ValueError):
-            docformatter.strip_docstring('r"""foo"""')
+    def test_strip_docstring_with_raw_string(self):
+        """Return docstring and raw open quote."""
+        docstring, open_quote = docformatter.strip_docstring('r"""foo"""')
+        assert docstring == "foo"
+        assert open_quote == 'r"""'
+
+        docstring, open_quote = docformatter.strip_docstring("R'''foo'''")
+        assert docstring == "foo"
+        assert open_quote == 'R"""'
+
+    @pytest.mark.unit
+    def test_strip_docstring_with_unicode_string(self):
+        """Return docstring and unicode open quote."""
+        docstring, open_quote = docformatter.strip_docstring("u'''foo'''")
+        assert docstring == "foo"
+        assert open_quote == 'u"""'
+
+        docstring, open_quote = docformatter.strip_docstring('U"""foo"""')
+        assert docstring == "foo"
+        assert open_quote == 'U"""'
 
     @pytest.mark.unit
     def test_strip_docstring_with_unknown(self):
@@ -494,9 +515,8 @@ class TestStrippers:
     def test_strip_docstring_with_single_quotes(self):
         """Raise ValueError when strings begin with single single quotes.
 
-        See requirement 1, always use triple double quotes. See issue
-        #66 for example of docformatter breaking code when encountering
-        single quote.
+        See requirement #1.  See issue #66 for example of docformatter breaking
+        code when encountering single quote.
         """
         with pytest.raises(ValueError):
             docformatter.strip_docstring("'hello\\''")
@@ -505,9 +525,8 @@ class TestStrippers:
     def test_strip_docstring_with_double_quotes(self):
         """Raise ValueError when strings begin with single double quotes.
 
-        See requirement 1, always use triple double quotes. See issue
-        #66 for example of docformatter breaking code when encountering
-        single quote.
+        See requirement #1.  See issue #66 for example of docformatter
+        breaking code when encountering single quote.
         """
         with pytest.raises(ValueError):
             docformatter.strip_docstring('"hello\\""')


### PR DESCRIPTION
This adds support for raw and unicode docstrings.  The type identifier can be either lower case or upper case (r, R, u, U).  The formatted docstring will retain the type identifier in the same case.

Cleaned up some linting and style warnings.

Closes #54.