### PR TITLE
fix: add argument to turn on/off many lines of short words being a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.egg
 *.egg-info/
 *.eggs/

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,34 @@
 docformatter
 ============
 
+.. |CI| image:: https://img.shields.io/github/workflow/status/PyCQA/docformatter/CI
+.. |CONTRIBUTORS| image:: https://img.shields.io/github/contributors/PyCQA/docformatter
+.. |COMMIT| image:: https://img.shields.io/github/last-commit/PyCQA/docformatter
+.. |BLACK| image:: https://img.shields.io/badge/%20style-black-000000.svg
+    :target: https://github.com/psf/black
+.. |ISORT| image:: https://img.shields.io/badge/%20imports-isort-%231674b1
+    :target: https://pycqa.github.io/isort/
+.. |SELF| image:: https://img.shields.io/badge/%20formatter-docformatter-fedcba.svg
+    :target: https://pycqa.github.io/docformatter/
+.. |DOCSTYLE| image:: https://img.shields.io/badge/%20style-numpy-459db9.svg
+    :target: https://numpydoc.readthedocs.io/en/latest/format.html
+
+.. |VERSION| image:: https://img.shields.io/pypi/v/docformatter
+.. |LICENSE| image:: https://img.shields.io/pypi/l/docformatter
+.. |PYVERS| image:: https://img.shields.io/pypi/pyversions/docformatter
+.. |PYMAT| image:: https://img.shields.io/pypi/format/docformatter
+.. |DD| image:: https://img.shields.io/pypi/dd/docformatter
+
++----------------+----------------------------------------------------------+
+| **Code**       + |BLACK| |ISORT|                                          +
++----------------+----------------------------------------------------------+
+| **Docstrings** + |SELF| |DOCSTYLE|                                        +
++----------------+----------------------------------------------------------+
+| **GitHub**     + |CI| |CONTRIBUTORS| |COMMIT|                             +
++----------------+----------------------------------------------------------+
+| **PyPi**       + |VERSION| |LICENSE| |PYVERS| |PYMAT| |DD|                +
++----------------+----------------------------------------------------------+
+
 Formats docstrings to follow `PEP 257`_.
 
 .. _`PEP 257`: http://www.python.org/dev/peps/pep-0257/
@@ -10,9 +38,7 @@ Formats docstrings to follow `PEP 257`_.
 Features
 ========
 
-*docformatter* currently automatically formats docstrings to follow a
-subset of the PEP 257 conventions. Below are the relevant items quoted
-from PEP 257.
+*docformatter* automatically formats docstrings to follow a subset of the PEP 257 conventions. Below are the relevant items quoted from PEP 257.
 
 - For consistency, always use triple double quotes around docstrings.
 - Triple quotes are used even though the string fits on one line.
@@ -169,6 +195,7 @@ Below is the help output::
                             line numbers are indexed at 1
       --docstring-length min_length max_length
                             apply docformatter to docstrings of given length range
+      --strict              strictly follow reST syntax to identify lists (see issue #67)
       --version             show program's version number and exit
       --config CONFIG       path to file containing docformatter options
 
@@ -236,8 +263,42 @@ PyCharm
 
 Head over to ``Preferences > Tools > File Watchers``, click the ``+`` icon and configure *docformatter* as shown below:
 
-.. image:: /images/pycharm-file-watcher-configurations.png
+.. image:: ./images/pycharm-file-watcher-configurations.png
    :alt: PyCharm file watcher configurations
+
+Marketing
+=========
+Do you use *docformatter*?  What style docstrings do you use?  Add some badges to your project's **README** and let everyone know.
+
+|SELF|
+
+.. code-block::
+
+	.. image:: https://img.shields.io/badge/%20formatter-docformatter-fedcba.svg
+  	  :target: https://pycqa.github.io/docformatter/
+
+.. image:: https://img.shields.io/badge/%20style-google-3666d6.svg
+	    :target: https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings
+
+.. code-block::
+
+	.. image:: https://img.shields.io/badge/%20style-google-3666d6.svg
+	    :target: https://google.github.io/styleguide/pyguide.html#s3.8-comments-and-docstrings
+
+|DOCSTYLE|
+
+.. code-block::
+
+	.. image:: https://img.shields.io/badge/%20style-numpy-459db9.svg
+  	  :target: https://numpydoc.readthedocs.io/en/latest/format.html
+
+.. image:: https://img.shields.io/badge/%20style-sphinx-0a507a.svg
+	    :target: https://www.sphinx-doc.org/en/master/usage/index.html
+
+.. code-block::
+
+	.. image:: https://img.shields.io/badge/%20style-sphinx-0a507a.svg
+	    :target: https://www.sphinx-doc.org/en/master/usage/index.html
 
 
 Issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ disable = [
 [tool.docformatter]
 wrap-summaries = 79
 wrap-descriptions = 72
+non-strict = false
 
 [tool.pydocstyle]
 convention = "pep257"
@@ -179,6 +180,7 @@ deps =
     pydocstyle
     pylint
     toml
+    untokenize
 commands =
     pycodestyle docformatter.py setup.py
     pydocstyle docformatter.py setup.py

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -356,7 +356,7 @@ Hello.
     """'''
         self.assertEqual(
             docstring,
-            docformatter.format_docstring('    ', docstring))
+            docformatter.format_docstring('    ', docstring, strict=False))
 
     def test_format_docstring_should_underlined_summaries_alone(self):
         docstring = '''"""
@@ -1058,7 +1058,8 @@ def foo():
 -    Hello world 
 -    """
 +    """Hello world."""
-''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split('\n')[2:]))
+''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split(
+                '\n')[2:]))
 
     def test_end_to_end_with_wrapping(self):
         with temporary_file('''\
@@ -1077,7 +1078,8 @@ def foo():
 -    """
 +    """Hello world this is a summary
 +    that will get wrapped."""
-''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split('\n')[2:]))
+''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split(
+                '\n')[2:]))
 
     def test_end_to_end_with_no_wrapping(self):
         with temporary_file('''\
@@ -1125,7 +1127,8 @@ def foo():
      """Wrapping is off, but it will still add
 -    the trailing period  """
 +    the trailing period."""
-''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split('\n')[2:]))
+''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split(
+                '\n')[2:]))
 
 
     def test_end_to_end_all_options(self):
@@ -1157,7 +1160,8 @@ def foo():
  
 -
      """
-''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split('\n')[2:]))
+''', '\n'.join(process.communicate()[0].decode().replace("\r", "").split(
+                '\n')[2:]))
 
     def test_invalid_range(self):
         process = run_docformatter(['--range', '0', '1', os.devnull])
@@ -1182,7 +1186,6 @@ Hello world"""
 '''.encode())[0].decode().replace("\r", "")
 
         self.assertEqual(0, process.returncode)
-
         self.assertEqual(
             '''"""Hello world."""\n''',
             result)

--- a/tests/_data/pyproject.toml
+++ b/tests/_data/pyproject.toml
@@ -1,4 +1,3 @@
 [tool.docformatter]
 recursive = true
 wrap-summaries = 82
-

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -238,7 +238,8 @@ class TestIsSomeSortdOfList:
         @param
         @param
         @param
-    """
+    """,
+            True,
         )
 
     @pytest.mark.unit
@@ -249,7 +250,8 @@ class TestIsSomeSortdOfList:
         Keyword arguments:
         real -- the real part (default 0.0)
         imag -- the imaginary part (default 0.0)
-    """
+    """,
+            True,
         )
 
     @pytest.mark.unit
@@ -264,7 +266,8 @@ class TestIsSomeSortdOfList:
           release-1.4/
           release-1.4.1/
           release-1.5/
-    """
+    """,
+            True,
         )
 
     @pytest.mark.unit
@@ -274,7 +277,38 @@ class TestIsSomeSortdOfList:
             """\
     Args:
         stream (BinaryIO): Binary stream (usually a file object).
-    """
+    """,
+            True,
+        )
+
+    @pytest.mark.unit
+    def test_is_some_sort_of_list_strict_wrap(self):
+        """Ignore many lines of short words as a list with strict set True.
+
+        See issue #67.
+        """
+        assert not docformatter.is_some_sort_of_list(
+            """\
+        Launch
+the
+rocket.
+    """,
+            True,
+        )
+
+    @pytest.mark.unit
+    def test_is_some_sort_of_list_non_strict_wrap(self):
+        """Identify many lines of short words as a list with strict False.
+
+        See issue #67.
+        """
+        assert docformatter.is_some_sort_of_list(
+            """\
+        Launch
+the
+rocket.
+    """,
+            False,
         )
 
 


### PR DESCRIPTION
The conditional in is_some_sort_of_list() function was identifying the README example
```
def launch_rocket():
    """Launch
the
rocket. Go colonize space."""
```
as a list because it was being processed as many lines of short words.  This required the --force-wrap argument to be set to produce the desired result.

This PR adds a new argument `--non-strict` to control the execution of this conditional.  Since the list format it is searching for is a non-standard reST list, this argument is assigned a default value of False.  Passing it on the command line or setting it True in the configuration file will restore current behavior (i.e., not strictly following reST).

Also adds some bling to the top of the README.

Closes #67 