### PR TITLE
fix: definitions corrupted with in-line comment

### DIFF
--- a/docformatter.py
+++ b/docformatter.py
@@ -233,14 +233,17 @@ def _format_code(
         previous_token_string = token_string
         previous_token_type = token_type
 
-        # If the current token is a newline, the previous token was a newline,
-        # and these two sequential newlines follow a function definition,
-        # ignore the blank line.
+        # If the current token is a newline, the previous token was a
+        # newline or a comment, and these two sequential newlines follow a
+        # function definition, ignore the blank line.
         if (
             len(modified_tokens) > 2
             and token_type in {tokenize.NL, tokenize.NEWLINE}
             and modified_tokens[-1][0] in {tokenize.NL, tokenize.NEWLINE}
-            and modified_tokens[-2][1] == ":"
+            and (
+                modified_tokens[-2][1] == ":"
+                or modified_tokens[-2][0] == tokenize.COMMENT
+            )
             and modified_tokens[-2][4][:3] == "def"
         ):
             pass

--- a/docformatter.py
+++ b/docformatter.py
@@ -233,9 +233,13 @@ def _format_code(
         previous_token_string = token_string
         previous_token_type = token_type
 
+        # If the current token is a newline, the previous token was a newline,
+        # and these two sequential newlines follow a function definition,
+        # ignore the blank line.
         if (
             len(modified_tokens) > 2
             and token_type in {tokenize.NL, tokenize.NEWLINE}
+            and modified_tokens[-1][0] in {tokenize.NL, tokenize.NEWLINE}
             and modified_tokens[-2][1] == ":"
             and modified_tokens[-2][4][:3] == "def"
         ):

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -632,6 +632,27 @@ def foo():\r
         self.assertEqual('\n\n\ndef my_func():\n"""Summary of my function."""\npass',
                          docformatter._format_code('\n\n\ndef my_func():\n\n"""Summary of my function."""\npass', args))
 
+    def test_format_code_extra_newline_following_comment(self):
+        args = {'summary_wrap_length': 79,
+                'description_wrap_length': 72,
+                'pre_summary_newline': False,
+                'pre_summary_space': False,
+                'make_summary_multi_line': False,
+                'post_description_blank': False,
+                'force_wrap': False,
+                'line_range': None}
+
+        docstring = ('''\
+def crash_rocket(location):    # pragma: no cover
+
+    """This is a docstring following an in-line comment."""
+    return location''')
+        self.assertEqual('''\
+def crash_rocket(location):    # pragma: no cover
+    """This is a docstring following an in-line comment."""
+    return location''',
+                         docformatter._format_code(docstring))
+
     def test_format_code_no_docstring(self):
         args = {'summary_wrap_length': 79,
                 'description_wrap_length': 72,

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -621,7 +621,7 @@ def foo():\r
 ''',
             docformatter.format_code(input))
 
-    def test__format_code_additional_empty_line_before_doc(self):
+    def test_format_code_additional_empty_line_before_doc(self):
         args = {'summary_wrap_length': 79,
                 'description_wrap_length': 72,
                 'pre_summary_newline': False,
@@ -631,6 +631,26 @@ def foo():\r
                 'line_range': None}
         self.assertEqual('\n\n\ndef my_func():\n"""Summary of my function."""\npass',
                          docformatter._format_code('\n\n\ndef my_func():\n\n"""Summary of my function."""\npass', args))
+
+    def test_format_code_no_docstring(self):
+        args = {'summary_wrap_length': 79,
+                'description_wrap_length': 72,
+                'pre_summary_newline': False,
+                'pre_summary_space': False,
+                'make_summary_multi_line': False,
+                'post_description_blank': False,
+                'force_wrap': False,
+                'line_range': None}
+        docstring = ("def pytest_addoption(parser: pytest.Parser) -> "
+        "None:\n    register_toggle.pytest_addoption(parser)\n")
+        self.assertEqual(docstring,
+                         docformatter._format_code(docstring, args))
+
+        docstring = ("def pytest_addoption(parser: pytest.Parser) -> "
+                     "None:    # pragma: no cover\n    "
+                     "register_toggle.pytest_addoption(parser)\n")
+        self.assertEqual(docstring,
+                         docformatter._format_code(docstring, args))
 
     def test_exclude(self):
         sources = {"/root"}


### PR DESCRIPTION
This was caused by the conditional introduced to strip the newline between a function definition and the docstring.  It was looking for a newline token that was two lines after a function definition (i.e., starts with 'def' and ends with ':').  This didn't account for a potential in-line comment which inserts another token before the '\n'.  When the '\n' following the in-line comment token was processed the above conditions were met and the '\n' was stripped.

This PR changes the condition so when a newline token is processed, it looks to see if the previous line was a newline and two lines after a function definition (i.e., starts with 'def' and ends with a ':' or a comment).

Closes #97
Closes #98