### PR TITLE
feat: add support for setup.cfg and tox.ini configuration files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,16 @@ docformatter
 ============
 
 .. |CI| image:: https://img.shields.io/github/workflow/status/PyCQA/docformatter/CI
+		:target: https://github.com/PyCQA/docformatter/actions/workflows/ci.yml
 .. |CONTRIBUTORS| image:: https://img.shields.io/github/contributors/PyCQA/docformatter
+		:target: https://github.com/PyCQA/docformatter/graphs/contributors
 .. |COMMIT| image:: https://img.shields.io/github/last-commit/PyCQA/docformatter
 .. |BLACK| image:: https://img.shields.io/badge/%20style-black-000000.svg
     :target: https://github.com/psf/black
 .. |ISORT| image:: https://img.shields.io/badge/%20imports-isort-%231674b1
     :target: https://pycqa.github.io/isort/
 .. |SELF| image:: https://img.shields.io/badge/%20formatter-docformatter-fedcba.svg
-    :target: https://pycqa.github.io/docformatter/
+    :target: https://github.com/PyCQA/docformatter
 .. |DOCSTYLE| image:: https://img.shields.io/badge/%20style-numpy-459db9.svg
     :target: https://numpydoc.readthedocs.io/en/latest/format.html
 
@@ -160,7 +162,8 @@ Below is the help output::
                         [--wrap-descriptions length] [--blank]
                         [--pre-summary-newline] [--make-summary-multi-line]
                         [--force-wrap] [--range start_line end_line]
-                        [--docstring-length min_length max_length] [--version]
+                        [--docstring-length min_length max_length]
+                        [--config CONFIG] [--version]
                         files [files ...]
 
     Formats docstrings to follow PEP 257.
@@ -176,60 +179,76 @@ Below is the help output::
       -e, --exclude         exclude directories and files by names
 
       --wrap-summaries length
-                            wrap long summary lines at this length; set to 0 to
-                            disable wrapping (default: 79)
+                            wrap long summary lines at this length; set
+                            to 0 to disable wrapping
+                            (default: 79)
       --wrap-descriptions length
-                            wrap descriptions at this length; set to 0 to disable
-                            wrapping (default: 72)
-      --blank               add blank line after description
+                            wrap descriptions at this length; set to 0 to 
+                            disable wrapping
+                            (default: 72)
+      --blank
+      											add blank line after elaborate description
+      											(default: False)
       --pre-summary-newline
-                            add a newline before the summary of a multi-line
-                            docstring
+                            add a newline before one-line or the summary of a
+                            multi-line docstring
+                            (default: False)
       --pre-summary-space
                             add a space between the opening triple quotes and
                             the first word in a one-line or summary line of a
                             multi-line docstring
+                            (default: False)
       --make-summary-multi-line
-                            add a newline before and after the summary of a one-
-                            line docstring
-      --force-wrap          force descriptions to be wrapped even if it may result
-                            in a mess
+                            add a newline before and after a one-line docstring
+                            (default: False)
+      --force-wrap
+      											force descriptions to be wrapped even if it may result
+      											in a mess
+      											(default: False)
       --range start_line end_line
-                            apply docformatter to docstrings between these lines;
+                            apply docformatter to docstrings between these lines; 
                             line numbers are indexed at 1
       --docstring-length min_length max_length
                             apply docformatter to docstrings of given length range
-      --strict              strictly follow reST syntax to identify lists (see issue #67)
-      --version             show program's version number and exit
-      --config CONFIG       path to file containing docformatter options
-
+      --non-strict
+      											do not strictly follow reST syntax to identify lists
+      											(see issue #67)
+      											(default: False)
+      --config CONFIG
+      											path to file containing docformatter options
+      											(default: ./pyproject.toml)
+      --version
+      											show program's version number and exit
 
 Possible exit codes:
 
 - **1** - if any error encountered
 - **3** - if any file needs to be formatted (in ``--check`` mode)
 
-docformatter options can also be stored in a configuration file.  Currently only
-pyproject.toml is supported.  Add section [tool.docformatter] with options listed using
-the same name as command line options.  For example::
+*docformatter* options can also be stored in a configuration file.  Currently only
+pyproject.toml, setup.cfg, and tox.ini are supported.  The configuration file can be passed with a full path.  For example::
+
+      docformatter --config ~/.secret/path/to/pyproject.toml
+
+If no configuration file is passed explicitly, *docformatter* will search the current directory for the supported files and use the first one found.  The order of precedence is pyproject.toml, setup.cfg, then tox.ini.
+
+Add section ``[tool.docformatter]`` with options listed using the same name as command line options.  For example:
+::
 
       [tool.docformatter]
       recursive = true
       wrap-summaries = 82
       blank = true
 
-Command line options take precedence.  The configuration file can be passed with a full
-path, otherwise docformatter will look in the current directory.  For example::
+The setup.cfg and tox.ini files will also support the ``[tool:docformatter]`` syntax.
 
-      docformatter --config ~/.secret/path/to/pyproject.toml
-
-See the discussions in `issue_39`_ and `issue_94`_ regarding docformatter and
+See the discussions in `issue_39`_ and `issue_94`_ regarding *docformatter* and
 black interactions.
 
 .. _`issue_39`: https://github.com/PyCQA/docformatter/issues/39
 .. _`issue_94`: https://github.com/PyCQA/docformatter/issues/94
 
-Wrapping descriptions
+Wrapping Descriptions
 =====================
 
 docformatter will wrap descriptions, but only in simple cases. If there is text
@@ -256,15 +275,15 @@ Git Hook
 
 .. code-block:: yaml
 
-  - repo: https://github.com/myint/docformatter
-    rev: v1.3.1
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.4
     hooks:
       - id: docformatter
         args: [--in-place]
 
 You will need to install ``pre-commit`` and run ``pre-commit install``.
 
-You may alternatively use  ``args: [--check]`` if you prefer the commit to fail instead of letting *docformatter* format  docstrings automatically.
+Whether you use ``args: [--check]`` or ``args: [--in-place]``, the commit will fail if *docformatter* processes a change.  The ``--in-place`` option fails because pre-commit does a diff check and fails if it detects a hook changed a file.  The ``--check`` option fails because *docformatter* returns a non-zero exit code.
 
 PyCharm
 -------
@@ -275,6 +294,13 @@ Head over to ``Preferences > Tools > File Watchers``, click the ``+`` icon and c
 
 .. image:: ./images/pycharm-file-watcher-configurations.png
    :alt: PyCharm file watcher configurations
+
+GitHub Actions
+--------------
+
+*docformatter* is one of the tools included in the `python-lint-plus`_ action.
+
+.. _`python-lint-plus`: https://github.com/marketplace/actions/python-code-style-quality-and-lint
 
 Marketing
 =========
@@ -316,7 +342,7 @@ Issues
 
 Bugs and patches can be reported on the `GitHub page`_.
 
-.. _`GitHub page`: https://github.com/myint/docformatter/issues
+.. _`GitHub page`: https://github.com/PyCQA/docformatter/issues
 
 
 Links

--- a/README.rst
+++ b/README.rst
@@ -226,11 +226,11 @@ Possible exit codes:
 - **3** - if any file needs to be formatted (in ``--check`` mode)
 
 *docformatter* options can also be stored in a configuration file.  Currently only
-pyproject.toml, setup.cfg, and tox.ini are supported.  The configuration file can be passed with a full path.  For example::
+``pyproject.toml``, ``setup.cfg``, and ``tox.ini`` are supported.  The configuration file can be passed with a full path.  For example::
 
       docformatter --config ~/.secret/path/to/pyproject.toml
 
-If no configuration file is passed explicitly, *docformatter* will search the current directory for the supported files and use the first one found.  The order of precedence is pyproject.toml, setup.cfg, then tox.ini.
+If no configuration file is passed explicitly, *docformatter* will search the current directory for the supported files and use the first one found.  The order of precedence is ``pyproject.toml``, ``setup.cfg``, then ``tox.ini``.
 
 Add section ``[tool.docformatter]`` with options listed using the same name as command line options.  For example:
 ::
@@ -240,7 +240,7 @@ Add section ``[tool.docformatter]`` with options listed using the same name as c
       wrap-summaries = 82
       blank = true
 
-The setup.cfg and tox.ini files will also support the ``[tool:docformatter]`` syntax.
+The ``setup.cfg`` and ``tox.ini`` files will also support the ``[tool:docformatter]`` syntax.
 
 See the discussions in `issue_39`_ and `issue_94`_ regarding *docformatter* and
 black interactions.

--- a/docformatter.py
+++ b/docformatter.py
@@ -233,14 +233,17 @@ def _format_code(
         previous_token_string = token_string
         previous_token_type = token_type
 
-        # If the current token is a newline, the previous token was a newline,
-        # and these two sequential newlines follow a function definition,
-        # ignore the blank line.
+        # If the current token is a newline, the previous token was a
+        # newline or a comment, and these two sequential newlines follow a
+        # function definition, ignore the blank line.
         if (
             len(modified_tokens) > 2
             and token_type in {tokenize.NL, tokenize.NEWLINE}
             and modified_tokens[-1][0] in {tokenize.NL, tokenize.NEWLINE}
-            and modified_tokens[-2][1] == ":"
+            and (
+                modified_tokens[-2][1] == ":"
+                or modified_tokens[-2][0] == tokenize.COMMENT
+            )
             and modified_tokens[-2][4][:3] == "def"
         ):
             pass

--- a/docformatter.py
+++ b/docformatter.py
@@ -233,9 +233,13 @@ def _format_code(
         previous_token_string = token_string
         previous_token_type = token_type
 
+        # If the current token is a newline, the previous token was a newline,
+        # and these two sequential newlines follow a function definition,
+        # ignore the blank line.
         if (
             len(modified_tokens) > 2
             and token_type in {tokenize.NL, tokenize.NEWLINE}
+            and modified_tokens[-1][0] in {tokenize.NL, tokenize.NEWLINE}
             and modified_tokens[-2][1] == ":"
             and modified_tokens[-2][4][:3] == "def"
         ):

--- a/docformatter.py
+++ b/docformatter.py
@@ -33,6 +33,7 @@ from __future__ import (
 )
 
 # Standard Library Imports
+import argparse
 import collections
 import contextlib
 import io
@@ -44,7 +45,8 @@ import sys
 import sysconfig
 import textwrap
 import tokenize
-from typing import Tuple
+from configparser import ConfigParser
+from typing import List, Tuple, Union
 
 # Third Party Imports
 import untokenize
@@ -97,6 +99,233 @@ class FormatResult(object):
     error = 1
     interrupted = 2
     check_failed = 3
+
+
+class Configurator:
+    """Read and store all the docformatter configuration information."""
+
+    parser = None
+    """Parser object."""
+
+    flargs_dct = {}
+    """Dictionary of configuration file arguments."""
+
+    configuration_file_lst = [
+        "pyproject.toml",
+        "setup.cfg",
+        "tox.ini",
+    ]
+    """List of supported configuration files."""
+
+    args: argparse.Namespace = None
+
+    def __init__(self, args: List[Union[bool, int, str]]) -> None:
+        """Initialize a Configurator class instance.
+
+        Parameters
+        ----------
+        args : list
+            Any command line arguments passed during invocation.
+        """
+        self.args_lst = args
+        self.parser = argparse.ArgumentParser(
+            description=__doc__,
+            prog="docformatter",
+        )
+
+        try:
+            self.config_file = self.args_lst[
+                self.args_lst.index("--config") + 1
+            ]
+        except ValueError:
+            for _configuration_file in self.configuration_file_lst:
+                if os.path.isfile(_configuration_file):
+                    self.config_file = f"./{_configuration_file}"
+                    break
+
+        self._do_read_configuration_file()
+
+    def do_parse_arguments(self) -> None:
+        """Parse configuration file and command line arguments."""
+        changes = self.parser.add_mutually_exclusive_group()
+        changes.add_argument(
+            "-i",
+            "--in-place",
+            action="store_true",
+            help="make changes to files instead of printing diffs",
+        )
+        changes.add_argument(
+            "-c",
+            "--check",
+            action="store_true",
+            help="only check and report incorrectly formatted files",
+        )
+        self.parser.add_argument(
+            "-r",
+            "--recursive",
+            action="store_true",
+            default=bool(self.flargs_dct.get("recursive", False)),
+            help="drill down directories recursively",
+        )
+        self.parser.add_argument(
+            "-e",
+            "--exclude",
+            nargs="*",
+            help="exclude directories and files by names",
+        )
+        self.parser.add_argument(
+            "--wrap-summaries",
+            default=int(self.flargs_dct.get("wrap-summaries", 79)),
+            type=int,
+            metavar="length",
+            help="wrap long summary lines at this length; "
+            "set to 0 to disable wrapping "
+            "(default: %(default)s)",
+        )
+        self.parser.add_argument(
+            "--wrap-descriptions",
+            default=int(self.flargs_dct.get("wrap-descriptions", 72)),
+            type=int,
+            metavar="length",
+            help="wrap descriptions at this length; "
+            "set to 0 to disable wrapping "
+            "(default: %(default)s)",
+        )
+        self.parser.add_argument(
+            "--blank",
+            dest="post_description_blank",
+            action="store_true",
+            default=bool(self.flargs_dct.get("blank", False)),
+            help="add blank line after description",
+        )
+        self.parser.add_argument(
+            "--pre-summary-newline",
+            action="store_true",
+            default=bool(self.flargs_dct.get("pre-summary-newline", False)),
+            help="add a newline before the summary of a multi-line docstring",
+        )
+        self.parser.add_argument(
+            "--pre-summary-space",
+            action="store_true",
+            default=bool(self.flargs_dct.get("pre-summary-space", False)),
+            help="add a space after the opening triple quotes",
+        )
+        self.parser.add_argument(
+            "--make-summary-multi-line",
+            action="store_true",
+            default=bool(
+                self.flargs_dct.get("make-summary-multi-line", False)
+            ),
+            help="add a newline before and after the summary of a "
+            "one-line docstring",
+        )
+        self.parser.add_argument(
+            "--force-wrap",
+            action="store_true",
+            default=bool(self.flargs_dct.get("force-wrap", False)),
+            help="force descriptions to be wrapped even if it may "
+            "result in a mess",
+        )
+        self.parser.add_argument(
+            "--range",
+            metavar="line",
+            dest="line_range",
+            default=self.flargs_dct.get("range", None),
+            type=int,
+            nargs=2,
+            help="apply docformatter to docstrings between these "
+            "lines; line numbers are indexed at 1",
+        )
+        self.parser.add_argument(
+            "--docstring-length",
+            metavar="length",
+            dest="length_range",
+            default=self.flargs_dct.get("docstring-length", None),
+            type=int,
+            nargs=2,
+            help="apply docformatter to docstrings of given length range",
+        )
+        self.parser.add_argument(
+            "--non-strict",
+            action="store_true",
+            default=bool(self.flargs_dct.get("non-strict", False)),
+            help="don't strictly follow reST syntax to identify lists (see "
+            "issue #67)",
+        )
+        self.parser.add_argument(
+            "--config", help="path to file containing docformatter options"
+        )
+        self.parser.add_argument(
+            "--version", action="version", version=f"%(prog)s {__version__}"
+        )
+        self.parser.add_argument(
+            "files", nargs="+", help="files to format or '-' for standard in"
+        )
+
+        self.args = self.parser.parse_args(self.args_lst[1:])
+
+        if self.args.line_range:
+            if self.args.line_range[0] <= 0:
+                self.parser.error("--range must be positive numbers")
+            if self.args.line_range[0] > self.args.line_range[1]:
+                self.parser.error(
+                    "First value of --range should be less than or equal "
+                    "to the second"
+                )
+
+        if self.args.length_range:
+            if self.args.length_range[0] <= 0:
+                self.parser.error(
+                    "--docstring-length must be positive numbers"
+                )
+            if self.args.length_range[0] > self.args.length_range[1]:
+                self.parser.error(
+                    "First value of --docstring-length should be less "
+                    "than or equal to the second"
+                )
+
+    def _do_read_configuration_file(self) -> None:
+        """Read docformatter options from a configuration file."""
+        if os.path.isfile(self.config_file):
+            argfile = os.path.basename(self.config_file)
+            for f in self.configuration_file_lst:
+                if argfile == f:
+                    break
+
+        fullpath, ext = os.path.splitext(self.config_file)
+        filename = os.path.basename(fullpath)
+
+        if ext == ".toml" and TOMLI_INSTALLED and filename == "pyproject":
+            self._do_read_toml_configuration()
+
+        if (ext == ".cfg" and filename == "setup") or (
+            ext == ".ini" and filename == "tox"
+        ):
+            self._do_read_parser_configuration()
+
+    def _do_read_toml_configuration(self) -> None:
+        """Load configuration information from a *.toml file."""
+        with open(self.config_file, "rb") as f:
+            config = tomli.load(f)
+
+        result = config.get("tool", {}).get("docformatter", None)
+        if result is not None:
+            self.flargs_dct = {
+                k: v if isinstance(v, list) else str(v)
+                for k, v in result.items()
+            }
+
+    def _do_read_parser_configuration(self) -> None:
+        """Load configuration information from a *.cfg or *.ini file."""
+        config = ConfigParser()
+        config.read(self.config_file)
+
+        for _section in ["tool:docformatter", "docformatter"]:
+            if _section in config.sections():
+                self.flargs_dct = {
+                    k: v if isinstance(v, list) else str(v)
+                    for k, v in config[_section].items()
+                }
 
 
 def has_correct_length(length_range, start, end):
@@ -237,17 +466,13 @@ def _format_code(
         # newline or a comment, and these two sequential newlines follow a
         # function definition, ignore the blank line.
         if (
-            len(modified_tokens) > 2
-            and token_type in {tokenize.NL, tokenize.NEWLINE}
-            and modified_tokens[-1][0] in {tokenize.NL, tokenize.NEWLINE}
-            and (
-                modified_tokens[-2][1] == ":"
-                or modified_tokens[-2][0] == tokenize.COMMENT
-            )
-            and modified_tokens[-2][4][:3] == "def"
+            len(modified_tokens) <= 2
+            or token_type not in {tokenize.NL, tokenize.NEWLINE}
+            or modified_tokens[-1][0] not in {tokenize.NL, tokenize.NEWLINE}
+            or modified_tokens[-2][1] != ":"
+            and modified_tokens[-2][0] != tokenize.COMMENT
+            or modified_tokens[-2][4][:3] != "def"
         ):
-            pass
-        else:
             modified_tokens.append(
                 (token_type, token_string, start, end, line)
             )
@@ -281,7 +506,7 @@ def format_docstring(
           on a line by themselves.
     """
     contents, open_quote = strip_docstring(docstring)
-    open_quote = open_quote + " " if pre_summary_space else open_quote
+    open_quote = f"{open_quote} " if pre_summary_space else open_quote
 
     # Skip if there are nested triple double quotes
     if contents.count(QUOTE_TYPES[0]):
@@ -733,193 +958,23 @@ def _format_code_with_args(source, args):
     )
 
 
-def find_config_file(args):
-    """Find the configuration file the user specified."""
-    flargs = {}
-
-    config_file = args[args.index("--config") + 1]
-
-    if os.path.isfile(config_file):
-        argfile = os.path.basename(config_file)
-        config_files = ["pyproject.toml"]
-        for f in config_files:
-            if argfile == f:
-                flargs = read_configuration_from_file(config_file)
-
-    return flargs
-
-
-def read_configuration_from_file(configfile):
-    """Read docformatter options from a configuration file."""
-    flargs = {}
-    fullpath, ext = os.path.splitext(configfile)
-    filename = os.path.basename(fullpath)
-
-    if ext == ".toml" and TOMLI_INSTALLED and filename == "pyproject":
-        with open(configfile, "rb") as f:
-            config = tomli.load(f)
-
-        result = config.get("tool", {}).get("docformatter", None)
-        if result is not None:
-            flargs = {
-                k: v if isinstance(v, list) else str(v)
-                for k, v in result.items()
-            }
-
-    return flargs
-
-
 def _main(argv, standard_out, standard_error, standard_in):
     """Run internal main entry point."""
-    # Standard Library Imports
-    import argparse
+    configurator = Configurator(argv)
+    configurator.do_parse_arguments()
 
-    flargs = find_config_file(argv) if "--config" in argv else {}
-    parser = argparse.ArgumentParser(description=__doc__, prog="docformatter")
-    changes = parser.add_mutually_exclusive_group()
-    changes.add_argument(
-        "-i",
-        "--in-place",
-        action="store_true",
-        help="make changes to files instead of printing diffs",
-    )
-    changes.add_argument(
-        "-c",
-        "--check",
-        action="store_true",
-        help="only check and report incorrectly formatted files",
-    )
-    parser.add_argument(
-        "-r",
-        "--recursive",
-        action="store_true",
-        default=bool(flargs.get("recursive", False)),
-        help="drill down directories recursively",
-    )
-    parser.add_argument(
-        "-e",
-        "--exclude",
-        nargs="*",
-        help="exclude directories and files by names",
-    )
-    parser.add_argument(
-        "--wrap-summaries",
-        default=int(flargs.get("wrap-summaries", 79)),
-        type=int,
-        metavar="length",
-        help="wrap long summary lines at this length; "
-        "set to 0 to disable wrapping "
-        "(default: %(default)s)",
-    )
-    parser.add_argument(
-        "--wrap-descriptions",
-        default=int(flargs.get("wrap-descriptions", 72)),
-        type=int,
-        metavar="length",
-        help="wrap descriptions at this length; "
-        "set to 0 to disable wrapping "
-        "(default: %(default)s)",
-    )
-    parser.add_argument(
-        "--blank",
-        dest="post_description_blank",
-        action="store_true",
-        default=bool(flargs.get("blank", False)),
-        help="add blank line after description",
-    )
-    parser.add_argument(
-        "--pre-summary-newline",
-        action="store_true",
-        default=bool(flargs.get("pre-summary-newline", False)),
-        help="add a newline before the summary of a multi-line docstring",
-    )
-    parser.add_argument(
-        "--pre-summary-space",
-        action="store_true",
-        default=bool(flargs.get("pre-summary-space", False)),
-        help="add a space before one-line or the summary of a multi-line "
-        "docstring",
-    )
-    parser.add_argument(
-        "--make-summary-multi-line",
-        action="store_true",
-        default=bool(flargs.get("make-summary-multi-line", False)),
-        help="add a newline before and after the summary of a "
-        "one-line docstring",
-    )
-    parser.add_argument(
-        "--force-wrap",
-        action="store_true",
-        default=bool(flargs.get("force-wrap", False)),
-        help="force descriptions to be wrapped even if it may "
-        "result in a mess",
-    )
-    parser.add_argument(
-        "--range",
-        metavar="line",
-        dest="line_range",
-        default=flargs.get("range", None),
-        type=int,
-        nargs=2,
-        help="apply docformatter to docstrings between these "
-        "lines; line numbers are indexed at 1",
-    )
-    parser.add_argument(
-        "--docstring-length",
-        metavar="length",
-        dest="length_range",
-        default=flargs.get("docstring-length", None),
-        type=int,
-        nargs=2,
-        help="apply docformatter to docstrings of given length range",
-    )
-    parser.add_argument(
-        "--non-strict",
-        action="store_true",
-        default=bool(flargs.get("non-strict", False)),
-        help="don't strictly follow reST syntax to identify lists (see issue "
-        "#67)",
-    )
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
-    parser.add_argument(
-        "--config", help="path to file containing docformatter options"
-    )
-    parser.add_argument(
-        "files", nargs="+", help="files to format or '-' for standard in"
-    )
-
-    args = parser.parse_args(argv[1:])
-
-    if args.line_range:
-        if args.line_range[0] <= 0:
-            parser.error("--range must be positive numbers")
-        if args.line_range[0] > args.line_range[1]:
-            parser.error(
-                "First value of --range should be less than or equal "
-                "to the second"
-            )
-
-    if args.length_range:
-        if args.length_range[0] <= 0:
-            parser.error("--docstring-length must be positive numbers")
-        if args.length_range[0] > args.length_range[1]:
-            parser.error(
-                "First value of --docstring-length should be less "
-                "than or equal to the second"
-            )
-
-    if "-" in args.files:
+    if "-" in configurator.args.files:
         _format_standard_in(
-            args,
-            parser=parser,
+            configurator.args,
+            parser=configurator.parser,
             standard_out=standard_out,
             standard_in=standard_in,
         )
     else:
         return _format_files(
-            args, standard_out=standard_out, standard_error=standard_error
+            configurator.args,
+            standard_out=standard_out,
+            standard_error=standard_error,
         )
 
 

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -603,14 +603,14 @@ def foo():
                          docformatter.format_code('"""\r\n'))
 
     def test_format_code_dominant_line_ending_style_preserved(self):
-        input = '''\
+        goes_in = '''\
 def foo():\r
     """\r
     Hello\r
     foo. This is a docstring.\r
     """\r
 '''
-        self.assertEqual(docformatter.CRLF, docformatter.find_newline(input.splitlines(True)))
+        self.assertEqual(docformatter.CRLF, docformatter.find_newline(goes_in.splitlines(True)))
         self.assertEqual(
             '''\
 def foo():\r
@@ -619,7 +619,7 @@ def foo():\r
     This is a docstring.\r
     """\r
 ''',
-            docformatter.format_code(input))
+            docformatter.format_code(goes_in))
 
     def test_format_code_additional_empty_line_before_doc(self):
         args = {'summary_wrap_length': 79,

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -632,6 +632,27 @@ def foo():\r
         self.assertEqual('\n\n\ndef my_func():\n"""Summary of my function."""\npass',
                          docformatter._format_code('\n\n\ndef my_func():\n\n"""Summary of my function."""\npass', args))
 
+    def test_format_code_extra_newline_following_comment(self):
+        args = {'summary_wrap_length': 79,
+                'description_wrap_length': 72,
+                'pre_summary_newline': False,
+                'pre_summary_space': False,
+                'make_summary_multi_line': False,
+                'post_description_blank': False,
+                'force_wrap': False,
+                'line_range': None}
+
+        docstring = ('''\
+def crash_rocket(location):    # pragma: no cover
+
+    """This is a docstring following an in-line comment."""
+    return location''')
+        self.assertEqual('''\
+def crash_rocket(location):    # pragma: no cover
+    """This is a docstring following an in-line comment."""
+    return location''',
+                         docformatter._format_code(docstring))
+
     def test_format_code_no_docstring(self):
         args = {'summary_wrap_length': 79,
                 'description_wrap_length': 72,

--- a/test_docformatter.py
+++ b/test_docformatter.py
@@ -621,7 +621,7 @@ def foo():\r
 ''',
             docformatter.format_code(input))
 
-    def test__format_code_additional_empty_line_before_doc(self):
+    def test_format_code_additional_empty_line_before_doc(self):
         args = {'summary_wrap_length': 79,
                 'description_wrap_length': 72,
                 'pre_summary_newline': False,
@@ -631,6 +631,26 @@ def foo():\r
                 'line_range': None}
         self.assertEqual('\n\n\ndef my_func():\n"""Summary of my function."""\npass',
                          docformatter._format_code('\n\n\ndef my_func():\n\n"""Summary of my function."""\npass', args))
+
+    def test_format_code_no_docstring(self):
+        args = {'summary_wrap_length': 79,
+                'description_wrap_length': 72,
+                'pre_summary_newline': False,
+                'pre_summary_space': False,
+                'make_summary_multi_line': False,
+                'post_description_blank': False,
+                'force_wrap': False,
+                'line_range': None}
+        docstring = ("def pytest_addoption(parser: pytest.Parser) -> "
+        "None:\n    register_toggle.pytest_addoption(parser)\n")
+        self.assertEqual(docstring,
+                         docformatter._format_code(docstring, args))
+
+        docstring = ("def pytest_addoption(parser: pytest.Parser) -> "
+                     "None:    # pragma: no cover\n    "
+                     "register_toggle.pytest_addoption(parser)\n")
+        self.assertEqual(docstring,
+                         docformatter._format_code(docstring, args))
 
     def test_exclude(self):
         sources = {"/root"}

--- a/tests/_data/setup.cfg
+++ b/tests/_data/setup.cfg
@@ -1,0 +1,4 @@
+[docformatter]
+blank = False
+wrap-summaries = 79
+wrap-descriptions = 72

--- a/tests/_data/tox.ini
+++ b/tests/_data/tox.ini
@@ -1,0 +1,4 @@
+[docformatter]
+wrap-descriptions = 72
+wrap-summaries = 79
+blank = False

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -26,7 +26,9 @@
 # SOFTWARE.
 """Module for testing the format_docstring() function."""
 
+
 # Standard Library Imports
+import itertools
 import random
 
 # Third Party Imports
@@ -272,22 +274,23 @@ class TestFormatWrap:
         random.seed(0)
 
         min_line_length = 50
-        for max_length in range(min_line_length, 100):
-            for num_indents in range(20):
-                indentation = " " * num_indents
-                formatted_text = indentation + docformatter.format_docstring(
-                    indentation=indentation,
-                    docstring=generate_random_docstring(
-                        max_word_length=min_line_length // 2
-                    ),
-                    summary_wrap_length=max_length,
-                )
+        for max_length, num_indents in itertools.product(
+            range(min_line_length, 100), range(20)
+        ):
+            indentation = " " * num_indents
+            formatted_text = indentation + docformatter.format_docstring(
+                indentation=indentation,
+                docstring=generate_random_docstring(
+                    max_word_length=min_line_length // 2
+                ),
+                summary_wrap_length=max_length,
+            )
 
-                for line in formatted_text.split("\n"):
-                    # It is not the formatter's fault if a word is too long to
-                    # wrap.
-                    if len(line.split()) > 1:
-                        assert len(line) <= max_length
+            for line in formatted_text.split("\n"):
+                # It is not the formatter's fault if a word is too long to
+                # wrap.
+                if len(line.split()) > 1:
+                    assert len(line) <= max_length
 
     @pytest.mark.unit
     def test_format_docstring_with_weird_indentation_and_punctuation(self):


### PR DESCRIPTION
This PR moves all the configuration business to a new class and adds support for setup.cfg and tox.ini.  docformatter will also now search the current directory for one of the supported configuration files and use the first one found if no file is explicitly passed (defaults to pyproject.toml).  Command line arguments still take precedence.

Closes #92 