### PR TITLE
feat: add option to place closing quotes on newline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,10 @@ Below is the help output::
       --make-summary-multi-line
                             add a newline before and after a one-line docstring
                             (default: False)
+      --close-quotes-on-newline
+                            place closing triple quotes on a new-line when a 
+                            one-line docstring wraps to two or more lines
+                            (default: False)
       --force-wrap
                             force descriptions to be wrapped even if it may result
                             in a mess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,10 +182,10 @@ deps =
     toml
     untokenize
 commands =
+    docformatter docformatter.py setup.py
     pycodestyle docformatter.py setup.py
     pydocstyle docformatter.py setup.py
     pylint docformatter.py setup.py
     rstcheck --report-level=1 README.rst
-    docformatter docformatter.py setup.py
     python -m doctest docformatter.py
 """

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -285,7 +285,6 @@ class TestFormatWrap:
                 ),
                 summary_wrap_length=max_length,
             )
-
             for line in formatted_text.split("\n"):
                 # It is not the formatter's fault if a word is too long to
                 # wrap.
@@ -440,6 +439,47 @@ num_iterations is the number of updates - instead of a better definition of conv
 '''.strip(),
             summary_wrap_length=30,
             tab_width=4,
+        )
+
+    @pytest.mark.unit
+    def test_format_docstring_for_multi_line_summary_alone(self):
+        """Place closing quotes on newline when wrapping one-liner."""
+        assert (
+            (
+                '''\
+"""This one-line docstring will be multi-line because it's quite
+    long.
+    """\
+'''
+            )
+            == docformatter.format_docstring(
+                "    ",
+                '''\
+"""This one-line docstring will be multi-line because it's quite long."""\
+''',
+                summary_wrap_length=69,
+                close_quotes_on_newline=True,
+            )
+        )
+
+    @pytest.mark.unit
+    def test_format_docstring_for_one_line_summary_alone_but_too_long(self):
+        """"""
+        assert (
+            (
+                '''\
+"""This one-line docstring will not be wrapped and quotes will be in-line."""\
+'''
+            )
+            == docformatter.format_docstring(
+                "    ",
+                '''\
+"""This one-line docstring will not be wrapped and quotes will be 
+in-line."""\
+''',
+                summary_wrap_length=88,
+                close_quotes_on_newline=True,
+            )
         )
 
 


### PR DESCRIPTION
A new argument `--close-quotes-on-newline` was added to allow the closing triple quotes to be placed on a newline when a one-line docstring is wrapped and takes two or more lines.  The default value is false to avoid breaking current use-cases.

Closes #9