### PR TITLE
fix: don't wrap URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip install .[tomli]
-        python -m pip install --quiet coverage coveralls pytest pytest-cov mock tox
+        python -m pip install --quiet coverage[toml] coveralls pytest pytest-cov mock tox
     - name: Run tests with tox
       run: |
         tox -e py
@@ -33,6 +33,7 @@ jobs:
       uses: miurahr/coveralls-python-action@patch-pyprject-toml
       with:
         base-path: .tox
+        flag-name: ${{ matrix.python-version }}
         parallel: true
 
   upload_coveralls:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         tox -e py
     - name: Create Coveralls report
-      uses: miurhr/coveralls-python-action@patch-pyprject-toml
+      uses: miurahr/coveralls-python-action@patch-pyprject-toml
       with:
         base-path: .tox
         parallel: true
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload coverage report to Coveralls
-        uses: miurhr/coveralls-python-action@patch-pyprject-toml
+        uses: miurahr/coveralls-python-action@patch-pyprject-toml
         with:
           base-path: .tox
           parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
       run: |
         tox -e py
     - name: Create Coveralls report
-      uses: miurahr/coveralls-python-action@patch-pyprject-toml
+      uses: miurhr/coveralls-python-action@patch-pyprject-toml
       with:
+        base-path: .tox
         parallel: true
 
   upload_coveralls:
@@ -40,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload coverage report to Coveralls
-        uses: miurahr/coveralls-python-action@patch-pyprject-toml
+        uses: miurhr/coveralls-python-action@patch-pyprject-toml
         with:
+          base-path: .tox
           parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,7 @@ jobs:
     - name: Run tests with tox
       run: |
         tox -e py
-    - name: Create Coveralls report
-      uses: miurahr/coveralls-python-action@patch-pyprject-toml
-      with:
-        base-path: .tox
-        flag-name: ${{ matrix.python-version }}
-        parallel: true
+        tox -e coverage
 
   upload_coveralls:
     name: Upload Results to Coveralls
@@ -45,4 +40,3 @@ jobs:
         uses: miurahr/coveralls-python-action@patch-pyprject-toml
         with:
           base-path: .tox
-          parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -29,13 +29,34 @@ jobs:
     - name: Run tests with tox
       run: |
         tox -e py
-        tox -e coverage
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-data
+        path: ".tox/.coverage.*"
 
   upload_coveralls:
     name: Upload Results to Coveralls
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install tox
+        run: python -m pip install tox
+      - name: Setup coverage
+        run: tox -e coverage --notest
+      - name: Download coverage data
+        uses: actions/download-artifacts@v3
+        with:
+          name: coverage-data
+          path: .tox
+      - name: Combine coverage reports
+        run: tox -e coverage
       - name: Upload coverage report to Coveralls
         uses: miurahr/coveralls-python-action@patch-pyprject-toml
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -26,9 +26,11 @@ jobs:
         python -m pip install -U pip
         python -m pip install .[tomli]
         python -m pip install --quiet coverage[toml] coveralls pytest pytest-cov mock tox
+    - name: Seetup test suite
+      run: tox -vv --notest
     - name: Run tests with tox
       run: |
-        tox -e py
+        tox -e py --skip-pkg-install
     - name: Upload coverage data
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup coverage
         run: tox -e coverage --notest
       - name: Download coverage data
-        uses: actions/download-artifacts@v3
+        uses: actions/download-artifact@v3
         with:
           name: coverage-data
           path: .tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,31 +11,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
+        python-version:
+          - "pypy-3.6-v7.3.3"
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
+          - "3.6"
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        python -m pip install .[tomli]
-        python -m pip install --quiet coverage[toml] coveralls pytest pytest-cov mock tox
-    - name: Seetup test suite
-      run: tox -vv --notest
-    - name: Run tests with tox
-      run: |
-        tox -e py --skip-pkg-install
-    - name: Upload coverage data
-      uses: actions/upload-artifact@v3
-      with:
-        name: coverage-data
-        path: ".tox/.coverage.*"
+      - name: Setup Python for tox
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install tox
+        run: python -m pip install tox
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }} for test
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup test suite
+        run: tox -vv --notest
+      - name: Run tests with tox
+        run: tox -e py --skip-pkg-install
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: ".tox/.coverage.*"
 
   upload_coveralls:
     name: Upload Results to Coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ htmlcov/
 poetry.lock
 .idea/
 .vscode/
+.tox/

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -25,7 +25,8 @@ options listed using the same name as command line argument.  For example:
       wrap-summaries = 82
       blank = true
 
-In ``setup.cfg``, add a ``[docformatter]`` section.
+In ``setup.cfg``, add a ``[docformatter]``, ``[tool.docformatter]``, or
+``[tool:docformatter]`` section.
 
 .. code-block:: yaml
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -15,7 +15,7 @@ If no configuration file is explicitly passed, ``docformatter`` will search
 the current directory for the supported files and use the first one found.
 The order of precedence is ``pyproject.toml``, ``setup.cfg``, then ``tox.ini``.
 
-In ``pyproject.toml`` or ``tox.ini``, add a section ``[tool.docformatter]`` with
+In ``pyproject.toml``, add a section ``[tool.docformatter]`` with
 options listed using the same name as command line argument.  For example:
 
 .. code-block:: yaml
@@ -25,8 +25,7 @@ options listed using the same name as command line argument.  For example:
       wrap-summaries = 82
       blank = true
 
-In ``setup.cfg``, add a ``[docformatter]``, ``[tool.docformatter]``, or
-``[tool:docformatter]`` section.
+In ``setup.cfg`` or ``tox.ini``, add a ``[docformatter]`` section.
 
 .. code-block:: yaml
 

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -194,6 +194,7 @@ the requirement falls in, the type of requirement, and whether
     ' docformatter_10.1.1', ' Shall not wrap lists or syntax directive statements', ' Derived', ' Shall', ' Yes'
     ' docformatter_10.1.1.1', ' Should allow wrapping of lists and syntax directive statements.', ' Stakeholder', ' Should', ' Yes [*PR #5*, *PR #93*]'
     ' docformatter_10.1.2', ' Should allow/disallow wrapping of one-line docstrings.', ' Derived', ' Should', ' No'
+    ' docformatter_10.1.3', ' Shall not wrap links that exceed the wrap length.', Derived', ' Shall', ' Yes [*PR #114*]'
     ' docformatter_10.2', ' Should format docstrings using NumPy style.', ' Style', ' Should', ' No'
     ' docformatter_10.3', ' Should format docstrings using Google style.', ' Style', ' Should', ' No'
     ' docformatter_10.4', ' Should format docstrings using Sphinx style.',' Style', ' Should', ' No'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,10 +187,13 @@ skipsdist = true
 [testenv]
 description = run the test suite using pytest under {basepython}
 deps =
+    charset_normalizer
     coverage[toml]
     mock
     pytest
     pytest-cov
+    tomli
+    untokenize
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
 commands =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,25 +175,44 @@ skipsdist = True
 isolated_build = True
 envlist =
     py{36,37,38,39,310,py36},
+    coverage,
     style
 
 [testenv:py{36,37,38,39,310,py36}]
+description = run the test suite using pytest under {basepython}
 deps =
-    coverage
+    coverage[toml]
     mock
     pytest
     pytest-cov
 setenv =
-    COVERAGE_FILE={toxinidir}/.coverage
+    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
 commands =
     pip install -U pip
     pip install .[tomli]
-    pytest -s -x -c ./pyproject.toml --cache-clear \
-        --cov-config=pyproject.toml --cov=docformatter \
-        --cov-branch --cov-report=term tests/
-    coverage xml --rcfile=pyproject.toml
+    pytest -s -x -c ./pyproject.toml \
+        --cache-clear \
+        --cov=docformatter \
+        --cov-config={toxinidir}/pyproject.toml \
+        --cov-branch \
+        tests/
+
+[testenv:coverage]
+description = combine coverage data and create report
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage
+skip_install = true
+deps =
+    coverage[toml]
+parallel_show_output = true
+commands =
+    coverage combine
+    coverage report -m
+    coverage xml -o {toxworkdir}/coverage.xml
+depends = py36, py37, py38, py39, py310, pypy36
 
 [testenv:style]
+description = run autoformatters and style checkers
 deps =
     docformatter
     pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,14 +171,20 @@ line_length = 79
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-skipsdist = True
-isolated_build = True
 envlist =
-    py{36,37,38,39,310,py36},
-    coverage,
+    py36
+    py37
+    py38
+    py39
+    py310
+    pypy3
+    coverage
     style
+isolated_build = true
+skip_missing_interpreters = true
+skipsdist = true
 
-[testenv:py{36,37,38,39,310,py36}]
+[testenv]
 description = run the test suite using pytest under {basepython}
 deps =
     coverage[toml]
@@ -188,8 +194,6 @@ deps =
 setenv =
     COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
 commands =
-    pip install -U pip
-    pip install .[tomli]
     pytest -s -x -c ./pyproject.toml \
         --cache-clear \
         --cov=docformatter \
@@ -209,11 +213,12 @@ commands =
     coverage combine
     coverage report -m
     coverage xml -o {toxworkdir}/coverage.xml
-depends = py36, py37, py38, py39, py310, pypy36
+depends = py36, py37, py38, py39, py310, pypy3
 
 [testenv:style]
 description = run autoformatters and style checkers
 deps =
+    charset_normalizer
     docformatter
     pycodestyle
     pydocstyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ pylint = "^2.12.0"
 pytest = "<7.0.0"
 pytest-cov = "^3.0.0"
 rstcheck = "<6.0.0"
+tox = "^3.25.0"
 Sphinx = "^5.0.0"
 twine = [
     {version="<4.0.0", python = "<3.7"},

--- a/tests/test_configuration_functions.py
+++ b/tests/test_configuration_functions.py
@@ -51,45 +51,61 @@ class TestConfigurator:
     @pytest.mark.unit
     def test_initialize_configurator_with_default(self):
         """Return a Configurator() instance using default pyproject.toml."""
-        unit_under_test = Configurator([])
+        argb = [
+            "/path/to/docformatter",
+            "",
+        ]
 
-        assert unit_under_test.config_file == "./pyproject.toml"
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
+
+        assert uut.args_lst == argb
+        assert uut.config_file == "./pyproject.toml"
 
     @pytest.mark.unit
     def test_initialize_configurator_with_pyproject_toml(self):
         """Return a Configurator() instance loaded from a pyproject.toml."""
         argb = [
+            "/path/to/docformatter",
+            "-c",
             "--config",
             "./tests/_data/pyproject.toml",
+            "",
         ]
 
-        unit_under_test = Configurator(argb)
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
 
-        assert unit_under_test.args is None
-        assert unit_under_test.flargs_dct == {
-            "recursive": "True",
-            "wrap-summaries": "82",
-        }
-        assert unit_under_test.configuration_file_lst == [
+        assert uut.args.check
+        assert not uut.args.in_place
+        assert uut.args_lst == argb
+        assert uut.config_file == "./tests/_data/pyproject.toml"
+        assert uut.configuration_file_lst == [
             "pyproject.toml",
             "setup.cfg",
             "tox.ini",
         ]
-        assert unit_under_test.args_lst == argb
-        assert unit_under_test.config_file == "./tests/_data/pyproject.toml"
+        assert uut.flargs_dct == {
+            "recursive": "True",
+            "wrap-summaries": "82",
+        }
 
     @pytest.mark.unit
     def test_initialize_configurator_with_setup_cfg(self):
         """Return docformatter configuration loaded from a setup.cfg file."""
         argb = [
+            "/path/to/docformatter",
+            "-c",
             "--config",
             "./tests/_data/setup.cfg",
+            "",
         ]
 
-        unit_under_test = Configurator(argb)
-        unit_under_test.do_parse_arguments()
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
 
-        assert unit_under_test.flargs_dct == {
+        assert uut.config_file == "./tests/_data/setup.cfg"
+        assert uut.flargs_dct == {
             "blank": "False",
             "wrap-summaries": "79",
             "wrap-descriptions": "72",
@@ -99,14 +115,18 @@ class TestConfigurator:
     def test_initialize_configurator_with_tox_ini(self):
         """Return docformatter configuration loaded from a tox.ini file."""
         argb = [
+            "/path/to/docformatter",
+            "-c",
             "--config",
             "./tests/_data/tox.ini",
+            "",
         ]
 
-        unit_under_test = Configurator(argb)
-        unit_under_test.do_parse_arguments()
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
 
-        assert unit_under_test.flargs_dct == {
+        assert uut.config_file == "./tests/_data/tox.ini"
+        assert uut.flargs_dct == {
             "blank": "False",
             "wrap-summaries": "79",
             "wrap-descriptions": "72",
@@ -116,46 +136,177 @@ class TestConfigurator:
     def test_unsupported_config_file(self):
         """Return empty configuration dict when file is unsupported."""
         argb = [
+            "/path/to/docformatter",
+            "-c",
             "--config",
             "./tests/conf.py",
+            "",
         ]
 
-        unit_under_test = Configurator(argb)
-        unit_under_test.do_parse_arguments()
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
 
-        assert unit_under_test.flargs_dct == {}
+        assert uut.config_file == "./tests/conf.py"
+        assert uut.flargs_dct == {}
 
     @pytest.mark.unit
     def test_cli_override_config_file(self):
         """Command line arguments override configuration file options."""
         argb = [
+            "/path/to/docformatter",
+            "-c",
             "--config",
             "./tests/_data/tox.ini",
             "--make-summary-multi-line",
             "--blank",
             "--wrap-summaries",
             "88",
+            "",
         ]
 
-        unit_under_test = Configurator(argb)
-        unit_under_test.do_parse_arguments()
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
 
-        assert unit_under_test.flargs_dct == {
+        assert uut.config_file == "./tests/_data/tox.ini"
+        assert uut.flargs_dct == {
             "blank": "False",
             "wrap-descriptions": "72",
             "wrap-summaries": "79",
         }
-        assert not unit_under_test.args.in_place
-        assert not unit_under_test.args.check
-        assert not unit_under_test.args.recursive
-        assert unit_under_test.args.exclude is None
-        assert unit_under_test.args.wrap_summaries == 88
-        assert unit_under_test.args.wrap_descriptions == 72
-        assert unit_under_test.args.post_description_blank
-        assert not unit_under_test.args.pre_summary_newline
-        assert not unit_under_test.args.pre_summary_space
-        assert unit_under_test.args.make_summary_multi_line
-        assert not unit_under_test.args.force_wrap
-        assert unit_under_test.args.line_range is None
-        assert unit_under_test.args.length_range is None
-        assert not unit_under_test.args.non_strict
+        assert not uut.args.in_place
+        assert uut.args.check
+        assert not uut.args.recursive
+        assert uut.args.exclude is None
+        assert uut.args.wrap_summaries == 88
+        assert uut.args.wrap_descriptions == 72
+        assert uut.args.post_description_blank
+        assert not uut.args.pre_summary_newline
+        assert not uut.args.pre_summary_space
+        assert uut.args.make_summary_multi_line
+        assert not uut.args.force_wrap
+        assert uut.args.line_range is None
+        assert uut.args.length_range is None
+        assert not uut.args.non_strict
+
+    @pytest.mark.unit
+    def test_only_format_in_line_range(self, capsys):
+        """Only format docstrings in line range."""
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--range",
+            "1",
+            "3",
+            "",
+        ]
+
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
+
+        assert uut.args.line_range == [1, 3]
+
+    @pytest.mark.unit
+    def test_low_line_range_is_zero(self, capsys):
+        """Raise parser error if the first value for the range is zero."""
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--range",
+            "0",
+            "10",
+            "",
+        ]
+
+        uut = Configurator(argb)
+        with pytest.raises(SystemExit):
+            uut.do_parse_arguments()
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert "--range must be positive numbers" in err
+
+    @pytest.mark.unit
+    def test_low_line_range_greater_than_high_line_range(self, capsys):
+        """Raise parser error if the first value for the range is greater than
+        the second."""
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--range",
+            "10",
+            "1",
+            "",
+        ]
+
+        uut = Configurator(argb)
+        with pytest.raises(SystemExit):
+            uut.do_parse_arguments()
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert (
+            "First value of --range should be less than or equal to the second"
+            in err
+        )
+
+    @pytest.mark.unit
+    def test_only_format_in_length_range(self, capsys):
+        """Only format docstrings in length range."""
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--docstring-length",
+            "25",
+            "55",
+            "",
+        ]
+
+        uut = Configurator(argb)
+        uut.do_parse_arguments()
+
+        assert uut.args.length_range == [25, 55]
+
+    @pytest.mark.unit
+    def test_low_length_range_is_zero(self, capsys):
+        """Raise parser error if the first value for the length range is
+        zero."""
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--docstring-length",
+            "0",
+            "10",
+            "",
+        ]
+
+        uut = Configurator(argb)
+        with pytest.raises(SystemExit):
+            uut.do_parse_arguments()
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert "--docstring-length must be positive numbers" in err
+
+    @pytest.mark.unit
+    def test_low_length_range_greater_than_high_length_range(self, capsys):
+        """Raise parser error if the first value for the range is greater than
+        the second."""
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--docstring-length",
+            "55",
+            "25",
+            "",
+        ]
+
+        uut = Configurator(argb)
+        with pytest.raises(SystemExit):
+            uut.do_parse_arguments()
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert (
+            "First value of --docstring-length should be less than or equal "
+            "to the second" in err
+        )

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -662,15 +662,7 @@ num_iterations is the number of updates - instead of a better definition of conv
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "args",
-        [
-            [
-                "--wrap-summaries",
-                "30",
-                "--tab-width",
-                "4",
-                "",
-            ]
-        ],
+        [["--wrap-summaries", "30", "--tab-width", "4", ""]],
     )
     def test_format_docstring_with_summary_only_and_wrap_and_tab_indentation(
         self,
@@ -701,14 +693,7 @@ num_iterations is the number of updates - instead of a better definition of conv
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "args",
-        [
-            [
-                "--wrap-summaries",
-                "69",
-                "--close-quotes-on-newline",
-                "",
-            ]
-        ],
+        [["--wrap-summaries", "69", "--close-quotes-on-newline", ""]],
     )
     def test_format_docstring_for_multi_line_summary_alone(
         self,
@@ -742,14 +727,7 @@ num_iterations is the number of updates - instead of a better definition of conv
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "args",
-        [
-            [
-                "--wrap-summaries",
-                "88",
-                "--close-quotes-on-newline",
-                "",
-            ]
-        ],
+        [["--wrap-summaries", "88", "--close-quotes-on-newline", ""]],
     )
     def test_format_docstring_for_one_line_summary_alone_but_too_long(
         self,
@@ -773,10 +751,163 @@ num_iterations is the number of updates - instead of a better definition of conv
             == uut._do_format_docstring(
                 INDENTATION,
                 '''\
-"""This one-line docstring will not be wrapped and quotes will be 
-in-line."""\
+"""This one-line docstring will not be wrapped and quotes will be in-line."""\
 ''',
             )
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [["--wrap-descriptions", "72", ""]],
+    )
+    def test_format_docstring_with_inline_links(
+        self,
+        test_args,
+        args,
+    ):
+        """Preserve links instead of wrapping them.
+
+        See issue #75. See requirement docformatter_10.1.3.
+        """
+        uut = Formator(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+"""This is a docstring with a link.
+
+    Here is an elaborate description containing a link.
+    `Area Under the Receiver Operating Characteristic Curve (ROC AUC)
+        <https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Further_interpretations>`_.
+    """\
+'''
+
+        assert '''\
+"""This is a docstring with a link.
+
+    Here is an elaborate description containing a link. `Area Under the
+    Receiver Operating Characteristic Curve (ROC AUC)
+    <https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Further_interpretations>`_.
+    """\
+''' == uut._do_format_docstring(
+            INDENTATION, docstring.strip()
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [["--wrap-descriptions", "72", ""]],
+    )
+    def test_format_docstring_with_target_links(
+        self,
+        test_args,
+        args,
+    ):
+        """Preserve links instead of wrapping them.
+
+        See issue #75. See requirement docformatter_10.1.3.
+        """
+        uut = Formator(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+"""This is another docstring with `a link`_.
+
+    .. a link: http://www.reliqual.com/wiki/how_to_use_ramstk/verification_and_validation_module/index.html.
+    """\
+'''
+
+        assert '''\
+"""This is another docstring with `a link`_.
+
+    .. a link: http://www.reliqual.com/wiki/how_to_use_ramstk/verification_and_validation_module/index.html.
+    """\
+''' == uut._do_format_docstring(
+            INDENTATION, docstring.strip()
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [["--wrap-descriptions", "72", ""]],
+    )
+    def test_format_docstring_with_sinmple_link(
+        self,
+        test_args,
+        args,
+    ):
+        """Preserve links instead of wrapping them.
+
+        See issue #75. See requirement docformatter_10.1.3.
+        """
+        uut = Formator(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+"""This is another docstring with a link.
+
+    See http://www.reliqual.com/wiki/how_to_use_ramstk/verification_and_validation_module/index.html for additional information.
+    """\
+'''
+
+        assert '''\
+"""This is another docstring with a link.
+
+    See
+    http://www.reliqual.com/wiki/how_to_use_ramstk/verification_and_validation_module/index.html
+    for additional information.
+    """\
+''' == uut._do_format_docstring(
+            INDENTATION, docstring.strip()
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [["--wrap-descriptions", "72", ""]],
+    )
+    def test_format_docstring_with_short_link(
+        self,
+        test_args,
+        args,
+    ):
+        """Short links will remain untouched.
+
+        See issue #75. See requirement docformatter_10.1.3.
+        """
+        uut = Formator(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+"""This is yanf with a short link.
+
+    See http://www.reliaqual.com for examples.
+    """\
+'''
+
+        assert '''\
+"""This is yanf with a short link.
+
+    See http://www.reliaqual.com for examples.
+    """\
+''' == uut._do_format_docstring(
+            INDENTATION, docstring.strip()
         )
 
 
@@ -1051,8 +1182,8 @@ class TestStripDocstring:
     ):
         """Raise ValueError when strings begin with single single quotes.
 
-        See requirement PEP_257_1.  See issue #66 for example of docformatter
-        breaking code when encountering single quote.
+        See requirement PEP_257_1.  See issue #66 for example of
+        docformatter breaking code when encountering single quote.
         """
         uut = Formator(
             test_args,
@@ -1073,8 +1204,8 @@ class TestStripDocstring:
     ):
         """Raise ValueError when strings begin with single double quotes.
 
-        See requirement PEP_257_1.  See issue #66 for example of docformatter
-        breaking code when encountering single quote.
+        See requirement PEP_257_1.  See issue #66 for example of
+        docformatter breaking code when encountering single quote.
         """
         uut = Formator(
             test_args,


### PR DESCRIPTION
Adds function and associated tests to reconnect URLs that are broken into parts when docstrings are wrapped.

Closes #75