### PR TITLE
Allow showing the diff when using --in-place or --check with --diff

### DIFF
--- a/src/docformatter/configuration.py
+++ b/src/docformatter/configuration.py
@@ -103,6 +103,13 @@ class Configurater:
             help="only check and report incorrectly formatted files",
         )
         self.parser.add_argument(
+            "-d",
+            "--diff",
+            action="store_true",
+            help="when used with `--check` or `--in-place`, also what changes "
+            "would be made",
+        )
+        self.parser.add_argument(
             "-r",
             "--recursive",
             action="store_true",

--- a/src/docformatter/format.py
+++ b/src/docformatter/format.py
@@ -155,8 +155,6 @@ class Formatter:
             try:
                 result = self._do_format_file(filename)
                 outcomes[result] += 1
-                if result == FormatResult.check_failed:
-                    print(unicode(filename), file=self.stderror)
             except IOError as exception:
                 outcomes[FormatResult.error] += 1
                 print(unicode(exception), file=self.stderror)
@@ -190,9 +188,13 @@ class Formatter:
             source = input_file.read()
             formatted_source = self._do_format_code(source)
 
+        ret = FormatResult.ok
+        show_diff = self.args.diff
+
         if source != formatted_source:
             if self.args.check:
-                return FormatResult.check_failed
+                print(unicode(filename), file=self.stderror)
+                ret = FormatResult.check_failed
             elif self.args.in_place:
                 with self.encodor.do_open_with_encoding(
                     filename,
@@ -200,6 +202,9 @@ class Formatter:
                 ) as output_file:
                     output_file.write(formatted_source)
             else:
+                show_diff = True
+
+            if show_diff:
                 # Standard Library Imports
                 import difflib
 
@@ -212,7 +217,7 @@ class Formatter:
                 )
                 self.stdout.write("\n".join(list(diff) + [""]))
 
-        return FormatResult.ok
+        return ret
 
     def _do_format_code(self, source):
         """Return source code with docstrings formatted.


### PR DESCRIPTION
It can be useful to show the difference, e.g. in CI so that users know what is or should be changed.

This adds a `--diff` option, that, when combined with `--check` or `--in-place`, will, in addition, show the diff to stdout.

fix #125 