### PR TITLE
chore: update CI workflow so 3.6 still runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - "3.8"
           - "3.7"
           - "3.6"
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
     steps:


### PR DESCRIPTION
Ubuntu latest is transitioning to 22.04 which doesn't support Python 3.6.  This sets the ci workflow runner explicitly to Ubuntu 20.04 to allow the Python 3.6 test suite to run.