### PR TITLE
Fix incorrect pyproject.toml parsing of boolean values

### DIFF
--- a/src/docformatter/configuration.py
+++ b/src/docformatter/configuration.py
@@ -113,7 +113,8 @@ class Configurater:
             "-r",
             "--recursive",
             action="store_true",
-            default=bool(self.flargs_dct.get("recursive", False)),
+            default=self.flargs_dct.get("recursive", "false").lower()
+            == "true",
             help="drill down directories recursively",
         )
         self.parser.add_argument(
@@ -141,7 +142,8 @@ class Configurater:
         self.parser.add_argument(
             "--force-wrap",
             action="store_true",
-            default=bool(self.flargs_dct.get("force-wrap", False)),
+            default=self.flargs_dct.get("force-wrap", "false").lower()
+            == "true",
             help="force descriptions to be wrapped even if it may "
             "result in a mess (default: False)",
         )
@@ -158,38 +160,42 @@ class Configurater:
             "--blank",
             dest="post_description_blank",
             action="store_true",
-            default=bool(self.flargs_dct.get("blank", False)),
+            default=self.flargs_dct.get("blank", "false").lower() == "true",
             help="add blank line after description (default: False)",
         )
         self.parser.add_argument(
             "--pre-summary-newline",
             action="store_true",
-            default=bool(self.flargs_dct.get("pre-summary-newline", False)),
+            default=self.flargs_dct.get("pre-summary-newline", "false").lower()
+            == "true",
             help="add a newline before the summary of a multi-line docstring "
             "(default: False)",
         )
         self.parser.add_argument(
             "--pre-summary-space",
             action="store_true",
-            default=bool(self.flargs_dct.get("pre-summary-space", False)),
+            default=self.flargs_dct.get("pre-summary-space", "false").lower()
+            == "true",
             help="add a space after the opening triple quotes "
             "(default: False)",
         )
         self.parser.add_argument(
             "--make-summary-multi-line",
             action="store_true",
-            default=bool(
-                self.flargs_dct.get("make-summary-multi-line", False)
-            ),
+            default=self.flargs_dct.get(
+                "make-summary-multi-line", "false"
+            ).lower()
+            == "true",
             help="add a newline before and after the summary of a one-line "
             "docstring (default: False)",
         )
         self.parser.add_argument(
             "--close-quotes-on-newline",
             action="store_true",
-            default=bool(
-                self.flargs_dct.get("close-quotes-on-newline", False)
-            ),
+            default=self.flargs_dct.get(
+                "close-quotes-on-newline", "false"
+            ).lower()
+            == "true",
             help="place closing triple quotes on a new-line when a "
             "one-line docstring wraps to two or more lines "
             "(default: False)",
@@ -217,7 +223,8 @@ class Configurater:
         self.parser.add_argument(
             "--non-strict",
             action="store_true",
-            default=bool(self.flargs_dct.get("non-strict", False)),
+            default=self.flargs_dct.get("non-strict", "false").lower()
+            == "true",
             help="don't strictly follow reST syntax to identify lists (see "
             "issue #67) (default: False)",
         )
@@ -238,7 +245,6 @@ class Configurater:
         )
 
         self.args = self.parser.parse_args(self.args_lst[1:])
-
         if self.args.line_range:
             if self.args.line_range[0] <= 0:
                 self.parser.error("--range must be positive numbers")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,17 @@ def temporary_file(contents, file_directory=".", file_prefix=""):
     finally:
         os.remove(f.name)
 
+@pytest.fixture(scope="function")
+def temporary_config(config, file_directory="/tmp",
+                     file_name="pyproject.toml"):
+    """Write contents to temporary configuration and yield it."""
+    f = open(f"{file_directory}/{file_name}", "wb")
+    try:
+        f.write(config.encode())
+        f.close()
+        yield f.name
+    finally:
+        os.remove(f.name)
 
 @pytest.fixture(scope="function")
 def run_docformatter(arguments, temporary_file):


### PR DESCRIPTION
Boolean options were always set as True when read from pyproject.toml.  This was the result of reading a string, which always returns a True when converted to boolean.  Defaults are now set using a "==".  Added tests to explicitly test configuration options read from pyproject.toml.

Closes #119 