### PR TITLE
feat: add file config options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 docformatter
 ============
 
-.. |CI| image:: https://img.shields.io/github/actions/workflow/status/PyCQA/docformatter/workflows/ci.yml?branch=main
+.. |CI| image:: https://img.shields
+.io/github/actions/workflow/status/PyCQA/docformatter/ci.yml?branch=master
     :target: https://github.com/PyCQA/docformatter/actions/workflows/ci.yml
 .. |COVERALLS| image:: https://img.shields.io/coveralls/github/PyCQA/docformatter
     :target: https://coveralls.io/github/PyCQA/docformatter

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,7 @@
 docformatter
 ============
 
-.. |CI| image:: https://img.shields
-.io/github/actions/workflow/status/PyCQA/docformatter/ci.yml?branch=master
+.. |CI| image:: https://img.shields.io/github/actions/workflow/status/PyCQA/docformatter/ci.yml?branch=master
     :target: https://github.com/PyCQA/docformatter/actions/workflows/ci.yml
 .. |COVERALLS| image:: https://img.shields.io/coveralls/github/PyCQA/docformatter
     :target: https://coveralls.io/github/PyCQA/docformatter

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -39,7 +39,7 @@ help output provides a summary of these options:
       -i, --in-place        make changes to files instead of printing diffs
       -c, --check           only check and report incorrectly formatted files
       -r, --recursive       drill down directories recursively
-      -e, --exclude         exclude directories and files by names
+      -e, --exclude         in recursive mode, exclude directories and files by names
 
       --wrap-summaries length
                             wrap long summary lines at this length; set
@@ -93,7 +93,7 @@ Possible exit codes from ``docformatter``:
 
 - **1** - if any error encountered
 - **2** - if it was interrupted
-- **3** - if any file needs to be formatted (in ``--check`` mode)
+- **3** - if any file needs to be formatted (in ``--check`` or ``--in-place`` mode)
 
 Use as a PyCharm File Watcher
 -----------------------------

--- a/src/docformatter/configuration.py
+++ b/src/docformatter/configuration.py
@@ -124,7 +124,8 @@ class Configurater:
             "-e",
             "--exclude",
             nargs="*",
-            help="exclude directories and files by names",
+            default=self.flargs_dct.get("exclude", None),
+            help="in recursive mode, exclude directories and files by names",
         )
         self.parser.add_argument(
             "--wrap-summaries",

--- a/src/docformatter/configuration.py
+++ b/src/docformatter/configuration.py
@@ -94,18 +94,21 @@ class Configurater:
             "-i",
             "--in-place",
             action="store_true",
+            default=self.flargs_dct.get("in-place", "false").lower() == "true",
             help="make changes to files instead of printing diffs",
         )
         changes.add_argument(
             "-c",
             "--check",
             action="store_true",
+            default=self.flargs_dct.get("check", "false").lower() == "true",
             help="only check and report incorrectly formatted files",
         )
         self.parser.add_argument(
             "-d",
             "--diff",
             action="store_true",
+            default=self.flargs_dct.get("diff", "false").lower() == "true",
             help="when used with `--check` or `--in-place`, also what changes "
             "would be made",
         )

--- a/src/docformatter/format.py
+++ b/src/docformatter/format.py
@@ -192,9 +192,9 @@ class Formatter:
         show_diff = self.args.diff
 
         if source != formatted_source:
+            ret = FormatResult.check_failed
             if self.args.check:
                 print(unicode(filename), file=self.stderror)
-                ret = FormatResult.check_failed
             elif self.args.in_place:
                 with self.encodor.do_open_with_encoding(
                     filename,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,10 +65,20 @@ def temporary_file(contents, file_directory=".", file_prefix=""):
         os.remove(f.name)
 
 @pytest.fixture(scope="function")
-def temporary_config(config, file_directory="/tmp",
-                     file_name="pyproject.toml"):
+def temporary_pyproject_toml(config, config_file_directory="/tmp",):
     """Write contents to temporary configuration and yield it."""
-    f = open(f"{file_directory}/{file_name}", "wb")
+    f = open(f"{config_file_directory}/pyproject.toml", "wb")
+    try:
+        f.write(config.encode())
+        f.close()
+        yield f.name
+    finally:
+        os.remove(f.name)
+
+@pytest.fixture(scope="function")
+def temporary_setup_cfg(config, config_file_directory="/tmp",):
+    """Write contents to temporary configuration and yield it."""
+    f = open(f"{config_file_directory}/setup.cfg", "wb")
     try:
         f.write(config.encode())
         f.close()

--- a/tests/test_configuration_functions.py
+++ b/tests/test_configuration_functions.py
@@ -300,3 +300,83 @@ class TestConfigurater:
             "First value of --docstring-length should be less than or equal "
             "to the second" in err
         )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "config",
+        [
+            """\
+[tool.docformatter]
+check = true
+diff = true
+recursive = true
+exclude = ["src/", "tests/"]
+"""
+        ],
+    )
+    def test_exclude_from_pyproject_toml(self,temporary_pyproject_toml,config,):
+        """Read exclude list from pyproject.toml.
+
+        See issue #120.
+        """
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--config",
+            "/tmp/pyproject.toml",
+            "",
+        ]
+
+        uut = Configurater(argb)
+        uut.do_parse_arguments()
+
+        assert uut.args.check
+        assert not uut.args.in_place
+        assert uut.args_lst == argb
+        assert uut.config_file == "/tmp/pyproject.toml"
+        assert uut.flargs_dct == {
+            "recursive": "True",
+            "check": "True",
+            "diff": "True",
+            "exclude": ["src/", "tests/"]
+        }
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "config",
+        [
+            """\
+[docformatter]
+check = true
+diff = true
+recursive = true
+exclude = ["src/", "tests/"]
+"""
+        ],
+    )
+    def test_exclude_from_setup_cfg(self,temporary_setup_cfg,config,):
+        """Read exclude list from setup.cfg.
+
+        See issue #120.
+        """
+        argb = [
+            "/path/to/docformatter",
+            "-c",
+            "--config",
+            "/tmp/setup.cfg",
+            "",
+        ]
+
+        uut = Configurater(argb)
+        uut.do_parse_arguments()
+
+        assert uut.args.check
+        assert not uut.args.in_place
+        assert uut.args_lst == argb
+        assert uut.config_file == "/tmp/setup.cfg"
+        assert uut.flargs_dct == {
+            "recursive": "true",
+            "check": "true",
+            "diff": "true",
+            "exclude": '["src/", "tests/"]'
+        }

--- a/tests/test_docformatter.py
+++ b/tests/test_docformatter.py
@@ -474,7 +474,12 @@ def foo():
             ["--range", "3", "1", os.devnull],
         ],
     )
-    def test_invalid_range(self, run_docformatter, arguments):
+    def test_invalid_range(
+        self,
+        run_docformatter,
+        arguments,
+        contents,
+    ):
         """"""
         if arguments[1] == "0":
             assert (
@@ -490,14 +495,24 @@ def foo():
     @pytest.mark.system
     @pytest.mark.parametrize("arguments", [[]])
     @pytest.mark.parametrize("contents", [""])
-    def test_no_arguments(self, run_docformatter, arguments):
+    def test_no_arguments(
+        self,
+        run_docformatter,
+        arguments,
+        contents,
+    ):
         """"""
         assert "" == run_docformatter.communicate()[1].decode()
 
     @pytest.mark.system
     @pytest.mark.parametrize("arguments", [["-"]])
     @pytest.mark.parametrize("contents", [""])
-    def test_standard_in(self, run_docformatter, arguments):
+    def test_standard_in(
+        self,
+        run_docformatter,
+        arguments,
+        contents,
+    ):
         result = (
             run_docformatter.communicate(
                 '''\
@@ -523,7 +538,10 @@ Hello world"""
     )
     @pytest.mark.parametrize("contents", [""])
     def test_standard_in_with_invalid_options(
-        self, run_docformatter, arguments
+        self,
+        run_docformatter,
+        arguments,
+        contents,
     ):
         """"""
         if arguments[0] == "foo.py":
@@ -574,9 +592,11 @@ pre-summary-space = false
     def test_no_pre_summary_space_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """No pre-summary space using configuration from pyproject.toml.
 
@@ -625,9 +645,11 @@ pre-summary-space = false
     def test_pre_summary_space_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """Pre-summary space using configuration from pyproject.toml.
 
@@ -680,9 +702,11 @@ pre-summary-space = false
     def test_no_pre_summary_newline_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """No pre-summary newline using configuration from pyproject.toml.
 
@@ -741,9 +765,11 @@ pre-summary-space = false
     def test_pre_summary_newline_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """Pre-summary newline using configuration from pyproject.toml.
 
@@ -802,9 +828,11 @@ pre-summary-space = false
     def test_no_pre_summary_multiline_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """No pre-summary multi-line using configuration from pyproject.toml.
 
@@ -857,9 +885,11 @@ pre-summary-space = false
     def test_pre_summary_multiline_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """Pre-summary multi-line using configuration from pyproject.toml.
 
@@ -915,9 +945,11 @@ pre-summary-space = false
     def test_no_blank_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """No blank after description using configuration from pyproject.toml.
 
@@ -944,9 +976,9 @@ pre-summary-space = false
 
     @pytest.mark.system
     @pytest.mark.parametrize(
-            "contents",
-            [
-                '''\
+        "contents",
+        [
+            '''\
                 class TestFoo():
                     """Summary docstring that is followed by a description.
 
@@ -954,33 +986,35 @@ pre-summary-space = false
                     inserted after it.
                     """
                 '''
-            ],
-        )
+        ],
+    )
     @pytest.mark.parametrize(
-            "config",
-            [
-                """\
+        "config",
+        [
+            """\
                             [tool.docformatter]
                             blank = true
                             """
-            ],
-        )
+        ],
+    )
     @pytest.mark.parametrize(
-            "arguments",
+        "arguments",
+        [
             [
-                [
-                    "--config",
-                    "/tmp/pyproject.toml",
-                ]
-            ],
-        )
+                "--config",
+                "/tmp/pyproject.toml",
+            ]
+        ],
+    )
     def test_blank_using_pyproject(
-                self,
-                run_docformatter,
-                temporary_config,
-                temporary_file,
-                arguments,
-        ):
+        self,
+        run_docformatter,
+        temporary_pyproject_toml,
+        temporary_file,
+        arguments,
+        contents,
+        config,
+    ):
         """Blank after description using configuration from pyproject.toml.
 
         See issue #119.
@@ -998,11 +1032,11 @@ pre-summary-space = false
                      """
 -                
 ''' == "\n".join(
-                run_docformatter.communicate()[0]
-                .decode()
-                .replace("\r", "")
-                .split("\n")[2:]
-            )
+            run_docformatter.communicate()[0]
+            .decode()
+            .replace("\r", "")
+            .split("\n")[2:]
+        )
 
     @pytest.mark.system
     @pytest.mark.parametrize(
@@ -1036,9 +1070,11 @@ class foo():
     def test_format_wrap_using_pyproject(
         self,
         run_docformatter,
-        temporary_config,
+        temporary_pyproject_toml,
         temporary_file,
         arguments,
+        contents,
+        config,
     ):
         """Wrap docstring using configuration from pyproject.toml.
 
@@ -1066,6 +1102,218 @@ class foo():
 +    in pypro
 +    ject.tom
 +    l."""
+''' == "\n".join(
+            run_docformatter.communicate()[0]
+            .decode()
+            .replace("\r", "")
+            .split("\n")[2:]
+        )
+
+
+class TestEndToEndSetupcfg:
+    """Class to test docformatter using setup.cfg for options."""
+
+    @pytest.mark.system
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            '''\
+class TestFoo():
+    """ Docstring that should not have a pre-summary space."""
+'''
+        ],
+    )
+    @pytest.mark.parametrize(
+        "config",
+        [
+            """\
+[docformatter]
+pre-summary-space = false
+"""
+        ],
+    )
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            [
+                "--config",
+                "/tmp/setup.cfg",
+            ]
+        ],
+    )
+    def test_no_pre_summary_space_using_setup_cfg(
+        self,
+        run_docformatter,
+        temporary_setup_cfg,
+        temporary_file,
+        arguments,
+        contents,
+        config,
+    ):
+        """No pre-summary space using configuration from setup.cfg.
+
+        See issue #119.
+        """
+        assert '''\
+@@ -1,2 +1,2 @@
+ class TestFoo():
+-    """ Docstring that should not have a pre-summary space."""
++    """Docstring that should not have a pre-summary space."""
+''' == "\n".join(
+            run_docformatter.communicate()[0]
+            .decode()
+            .replace("\r", "")
+            .split("\n")[2:]
+        )
+
+    @pytest.mark.system
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            '''\
+class TestFoo():
+    """ Docstring that should not have a pre-summary space."""
+'''
+        ],
+    )
+    @pytest.mark.parametrize(
+        "config",
+        [
+            """\
+[docformatter]
+in-place = true
+check = false
+diff = false
+"""
+        ],
+    )
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            [
+                "--config",
+                "/tmp/setup.cfg",
+            ]
+        ],
+    )
+    def test_in_place_using_setup_cfg(self,
+        run_docformatter,
+        temporary_setup_cfg,
+        temporary_file,
+        arguments,
+        contents,
+        config,):
+        """Make changes in-place if set in setup.cfg.
+
+        See issue #122.
+        """
+        assert '' == "\n".join(
+            run_docformatter.communicate()[0]
+            .decode()
+            .replace("\r", "")
+            .split("\n")[2:]
+        )
+        with open(temporary_file, "r") as f:
+            assert f.read() == '''\
+class TestFoo():
+    """Docstring that should not have a pre-summary space."""
+'''
+
+    @pytest.mark.system
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            '''\
+class TestFoo():
+    """ Docstring that should not have a pre-summary space."""
+'''
+        ],
+    )
+    @pytest.mark.parametrize(
+        "config",
+        [
+            """\
+[docformatter]
+in-place = true
+check = true
+diff = false
+"""
+        ],
+    )
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            [
+                "--config",
+                "/tmp/setup.cfg",
+            ]
+        ],
+    )
+    def test_check_using_setup_cfg(self,
+        run_docformatter,
+        temporary_setup_cfg,
+        temporary_file,
+        arguments,
+        contents,
+        config,):
+        """Just check for changes if set in setup.cfg.
+
+        See issue #122.
+        """
+        _results = run_docformatter.communicate()
+        assert '' == "\n".join(
+            _results[0]
+            .decode()
+            .replace("\r", "")
+            .split("\n")[2:]
+        )
+        assert temporary_file == _results[1].decode().rstrip("\n")
+
+    @pytest.mark.system
+    @pytest.mark.parametrize(
+        "contents",
+        [
+            '''\
+class TestFoo():
+    """ Docstring that should not have a pre-summary space."""
+'''
+        ],
+    )
+    @pytest.mark.parametrize(
+        "config",
+        [
+            """\
+[docformatter]
+check = true
+diff = true
+"""
+        ],
+    )
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            [
+                "--config",
+                "/tmp/setup.cfg",
+            ]
+        ],
+    )
+    def test_check_with_diff_using_setup_cfg(self,
+        run_docformatter,
+        temporary_setup_cfg,
+        temporary_file,
+        arguments,
+        contents,
+        config,):
+        """Check for changes and print diff if set in setup.cfg.
+
+        See issue #122.
+        """
+        assert '''\
+@@ -1,2 +1,2 @@
+ class TestFoo():
+-    """ Docstring that should not have a pre-summary space."""
++    """Docstring that should not have a pre-summary space."""
 ''' == "\n".join(
             run_docformatter.communicate()[0]
             .decode()

--- a/tests/test_docformatter.py
+++ b/tests/test_docformatter.py
@@ -1196,28 +1196,33 @@ diff = false
             ]
         ],
     )
-    def test_in_place_using_setup_cfg(self,
+    def test_in_place_using_setup_cfg(
+        self,
         run_docformatter,
         temporary_setup_cfg,
         temporary_file,
         arguments,
         contents,
-        config,):
+        config,
+    ):
         """Make changes in-place if set in setup.cfg.
 
         See issue #122.
         """
-        assert '' == "\n".join(
+        assert "" == "\n".join(
             run_docformatter.communicate()[0]
             .decode()
             .replace("\r", "")
             .split("\n")[2:]
         )
         with open(temporary_file, "r") as f:
-            assert f.read() == '''\
+            assert (
+                f.read()
+                == '''\
 class TestFoo():
     """Docstring that should not have a pre-summary space."""
 '''
+            )
 
     @pytest.mark.system
     @pytest.mark.parametrize(
@@ -1249,23 +1254,22 @@ diff = false
             ]
         ],
     )
-    def test_check_using_setup_cfg(self,
+    def test_check_using_setup_cfg(
+        self,
         run_docformatter,
         temporary_setup_cfg,
         temporary_file,
         arguments,
         contents,
-        config,):
+        config,
+    ):
         """Just check for changes if set in setup.cfg.
 
         See issue #122.
         """
         _results = run_docformatter.communicate()
-        assert '' == "\n".join(
-            _results[0]
-            .decode()
-            .replace("\r", "")
-            .split("\n")[2:]
+        assert "" == "\n".join(
+            _results[0].decode().replace("\r", "").split("\n")[2:]
         )
         assert temporary_file == _results[1].decode().rstrip("\n")
 
@@ -1298,13 +1302,15 @@ diff = true
             ]
         ],
     )
-    def test_check_with_diff_using_setup_cfg(self,
+    def test_check_with_diff_using_setup_cfg(
+        self,
         run_docformatter,
         temporary_setup_cfg,
         temporary_file,
         arguments,
         contents,
-        config,):
+        config,
+    ):
         """Check for changes and print diff if set in setup.cfg.
 
         See issue #122.


### PR DESCRIPTION
Adds new options that can be set in the config files.  These include --check, --diff, --in-place, and --exclude.  Also has docformatter exit with non-zero even when --in-place changes files.

Closes #120, #121, #122