### PR TITLE
docs: fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Bug Fixes
 - Add pyproject.toml support for config \(Issue \#10\) [\#77](https://github.com/PyCQA/docformatter/pull/77) ([weibullguy](https://github.com/weibullguy))
 - Bugfix --wrap-summaries 0 now fully disables summary wrapping [\#74](https://github.com/PyCQA/docformatter/pull/74) ([howeaj](https://github.com/howeaj))
 - Better document --docstring-length option and add it to the readme [\#72](https://github.com/PyCQA/docformatter/pull/72) ([AntoineD](https://github.com/AntoineD))
-- Removed the empty line between function definiton and docstring \#51 [\#53](https://github.com/PyCQA/docformatter/pull/53) ([dabauxi](https://github.com/dabauxi))
+- Removed the empty line between function definition and docstring \#51 [\#53](https://github.com/PyCQA/docformatter/pull/53) ([dabauxi](https://github.com/dabauxi))
 - Pre-Summary Space Option [\#46](https://github.com/PyCQA/docformatter/pull/46) ([alecmerdler](https://github.com/alecmerdler))
 
 ## [v1.4](https://github.com/PyCQA/docformatter/tree/v1.4) (2020-12-27)

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -210,7 +210,7 @@ the requirement falls in, the type of requirement, and whether
     ' docformatter_11.8',' Should read docstrings from stdin and report results to stdout.', ' Stakeholder', ' Should', ' Yes [*PR #8*]'
 
 Requirement ID's that begin with PEP_257 are taken from PEP 257.  Those
-prefaced with docformatter are un-releated to PEP 257.
+prefaced with docformatter are un-related to PEP 257.
 
 Test Suite
 ----------

--- a/src/docformatter/encode.py
+++ b/src/docformatter/encode.py
@@ -70,7 +70,7 @@ class Encoder:
     def do_find_newline(self, source: str) -> Dict[int, int]:
         """Return type of newline used in source.
 
-        Paramaters
+        Parameters
         ----------
         source : list
             A list of lines.

--- a/tests/test_encoding_functions.py
+++ b/tests/test_encoding_functions.py
@@ -55,7 +55,7 @@ class TestDetectEncoding:
     def test_detect_encoding_with_explicit_utf_8(
         self, temporary_file, contents
     ):
-        """Return utf-8 when explicitely set in file."""
+        """Return utf-8 when explicitly set in file."""
         uut = Encoder()
         uut.do_detect_encoding(temporary_file)
 

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -446,7 +446,7 @@ class TestFormatWrap:
         test_args,
         args,
     ):
-        """Wrap each paragraph in the long description seperately.
+        """Wrap each paragraph in the long description separately.
 
         See issue #127.
         """


### PR DESCRIPTION
Found via `codespell -S .tox -L dedented,pullrequests`