### PR TITLE
chore: drop support for Python3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "pypy-3.6-v7.3.3"
+          - "pypy-3.8-v7.3.10"
           - "3.10"
           - "3.9"
           - "3.8"
           - "3.7"
-          - "3.6"
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
     steps:

--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,14 @@ Or, if you want to use pyproject.toml to configure docformatter::
 
     $ pip install --upgrade docformatter[tomli]
 
+Or, if you want to use a release candidate (or any other tag)::
+
+    $ pip install git+https://github.com/PyCQA/docformatter.git@<RC_TAG>
+
+Where <RC_TAG> is the release candidate tag you'd like to install.  Release
+candidate tags will have the format v1.6.0-rc.1  Release candidates will also be
+made available as a Github Release.
+
 Example
 =======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers=[
           'Intended Audience :: Developers',
           'Environment :: Console',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: 3.9',
@@ -32,50 +31,33 @@ packages = [{include = "docformatter", from = "src"}]
 include = ["LICENSE"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
-charset_normalizer = "^2.0.0"
-tomli = [
-    {version="<2.0.0", optional=true, python="<3.7"},
-    {version="^2.0.0", optional=true, python=">=3.7"},
-]
+python = "^3.7"
+charset_normalizer = "^3.0.0"
+tomli = {version = "^2.0.0", optional = true}
 untokenize = "^0.1.1"
 
 [tool.poetry.dev-dependencies]
-autopep8 = "^1.7.0"
-black = [
-    {version = "^22.0.0", python = ">=3.6.2"},
-]
-coverage = [
-    {extras = ["toml"], version = "^6.2.0", python = "<3.7"},
-    {extras = ["toml"], version = "^6.4.0", python = ">=3.7"},
-]
-isort = [
-    {version = "<5.10.0", python = "<3.6.1"},
-    {version = "^5.10.0", python = ">=3.6.1"},
-]
+autopep8 = "^2.0.0"
+black = "^22.0.0"
+coverage = {extras = ["toml"], version = "^6.4.0"}
+isort = "^5.10.0"
 mock = "^4.0.0"
-mypy = "0.971"
+mypy = "0.991"
 pycodestyle = "^2.8.0"
 pydocstyle = "^6.1.1"
 pylint = [
     {version = "^2.12.0", python = "<3.7.2"},
     {version = "^2.14.0", python = ">=3.7.2"},
 ]
-pytest = [
-    {version = "<7.1.0", python = "<3.7"},
-    {version = "^7.1.0", python = ">=3.7"},
+pytest = "^7.1.0"
+pytest-cov = "^4.0.0"
+rstcheck = "^6.1.0"
+tox = "<4.0.0"
+Sphinx = [
+    {version = "5.3.0", python = "<3.8"},
+    {version = "^6.0.0", python = ">=3.8"},
 ]
-pytest-cov = "^3.0.0"
-rstcheck = [
-    {version = "<6.0.0", python = "<3.7"},
-    {version = "^6.1.0", python = ">=3.7"},
-]
-tox = "^3.25.0"
-Sphinx = "^5.0.0"
-twine = [
-    {version="<4.0.0", python = "<3.7"},
-    {version="^4.0.0", python = ">=3.7"},
-]
+twine = "^4.0.0"
 
 [tool.poetry.extras]
 tomli = ["tomli"]
@@ -153,7 +135,7 @@ output = 'coverage.xml'
 
 [tool.black]
 line-length = 79
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -188,7 +170,6 @@ line_length = 79
 legacy_tox_ini = """
 [tox]
 envlist =
-    py36
     py37
     py38
     py39
@@ -202,12 +183,11 @@ skipsdist = true
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
-    pypy-3.6: pypy3
+    pypy-3.8: pypy3
 
 [testenv]
 description = run the test suite using pytest under {basepython}
@@ -243,7 +223,7 @@ commands =
     coverage combine
     coverage report -m
     coverage xml -o {toxworkdir}/coverage.xml
-depends = py36, py37, py38, py39, py310, pypy3
+depends = py37, py38, py39, py310, pypy3
 
 [testenv:style]
 description = run autoformatters and style checkers

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -45,7 +45,7 @@ import docformatter
 
 
 class TestFindPyFiles:
-    """Class for testing the find_py_files() Function."""
+    """Class for testing the find_py_files() function."""
 
     @pytest.mark.unit
     def test_is_hidden(self):


### PR DESCRIPTION
Drops support for Python 3.6 (one year post end-of-life).
Updates dependencies to latest versions.

Closes #118