### PR TITLE
chore: update GitHub action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Execute Test Suite
 on:
   push:
     branches:
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }} for test
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup test suite

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -1,19 +1,12 @@
 # This workflow runs when a pull request is closed.
 #
-# - Job 1:
-#     - Gets list of PR labels.
-#     - Get release version from VERSION.
-#     - IF 'release' label:
-#         - Cut release.
-#     - IF release is cut:
-#         - Build artifacts.
-#         - Upload to Test PyPi if build succeeds. (Future)
-#         - Test install from Test PyPi. (Future)
-#         - Upload to PyPi if test install succeeds. (Future)
-# - Job 2 (needs job 1):
-#     - Close old milestone.
-#     - Create new minor version milestone.
-#     - Create new major version milestone.
+# - Gets list of PR labels.
+# - IF 'release' label:
+#   - Get release version using Poetry.
+#   - Get next semantic version.
+#   - Close old milestones.
+#   - Create new minor version milestone.
+#   - Create new major version milestone.
 name: Do Release Workflow
 
 on:
@@ -24,12 +17,12 @@ on:
       - closed
 
 jobs:
-  cut-release:
-    name: Cut New Release
+  create_new_milestone:
+    name: Create New Milestone
+    needs: cut-release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -42,103 +35,33 @@ jobs:
         if: contains(steps.prlabels.outputs.labels, ' release ')
         run: |
           pip install poetry
-          echo "::set-output name=rel_version::$(echo $(poetry version | cut -d' ' -f2))"
-          echo "cut_release=1" >> $GITHUB_ENV
-
-      - name: Cut the release
-        id: cutrelease
-        if: ${{ env.cut_release == 1 }}
-        uses: release-drafter/release-drafter@master
-        with:
-          name: "v${{ steps.relversion.outputs.rel_version }}"
-          tag: "v${{ steps.relversion.outputs.rel_version }}"
-          version: "${{ steps.relversion.outputs.rel_version }}"
-          prerelease: false
-          publish: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print release info
-        run: |
-          echo ${{ steps.cutrelease.outputs.id }}
-          echo ${{ steps.cutrelease.outputs.name }}
-          echo ${{ steps.cutrelease.outputs.tag_name }}
-          echo ${{ steps.cutrelease.outputs.html_url }}
-          echo ${{ steps.cutrelease.outputs.upload_url }}
-
-      - name: Build release
-        if: startsWith(steps.cutrelease.outputs.tag_name, 'v')
-        id: build
-        run: |
-          pip install -U pip poetry twine
-          poetry build && twine check dist/* && echo "build_ok=1" >> $GITHUB_ENV
-
-#      - name: Publish to Test PyPi
-#        if: ${{ env.build_ok == 1 }}
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          user: __token__
-#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository_url: https://test.pypi.org/legacy/
-
-#      - name: Test install from Test PyPI
-#        if: ${{ env.build_ok == 1 }}
-#        run: |
-#          sudo apt-get update
-#          pip install \
-#          --index-url https://test.pypi.org/simple/ \
-#          --extra-index-url https://pypi.org/simple \
-#          docformatter==${{ steps.relversion.outputs.rel_version }} && echo "install_ok=1" >> $GITHUB_ENV
-
-#      - name: Publish to PyPi
-#        if: ${{ env.install_ok == 1 }}
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          user: __token__
-#          password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Upload wheel to Release
-        id: upload-wheel
-        if: ${{ env.build_ok == 1 }}
-        uses: shogo82148/actions-upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.cutrelease.outputs.upload_url }}
-
-  create_new_milestone:
-    name: Create New Milestone
-    needs: cut-release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.2.0
-        with:
-          fetch-depth: 0
-
-      - name: Get new version
-        id: newversion
-        run: |
-          pip install poetry
-          echo "::set-output name=version::$(echo $(poetry version | cut -d' ' -f2))"
+          echo "version=$(echo $(poetry version | cut -d' ' -f2))" >> $GITHUB_OUTPUT
+          echo "do_milestones=1" >> $GITHUB_ENV
 
       - name: Get next semantic version
         id: nextversion
+        if: ${{ env.do_milestones == 1 }}
         uses: WyriHaximus/github-action-next-semvers@v1.1.0
         with:
-          version: ${{ steps.newversion.outputs.version }}
+          version: ${{ steps.relversion.outputs.version }}
 
       - name: Close old milestone
+        if: ${{ env.do_milestones == 1 }}
         uses: WyriHaximus/github-action-close-milestone@master
         with:
-          number: ${{ steps.newversion.outputs.version }}
+          number: ${{ steps.relversion.outputs.version }}
 
       - name: Create new minor release milestone
-        uses: WyriHaximus/github-action-create-milestone@master
+        if: ${{ env.do_milestones == 1 }}
+        uses: WyriHaximus/github-action-create-milestone@v1.2.0
         with:
           title: "${{ steps.nextversion.outputs.v_minor }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create new major release milestone
-        uses: WyriHaximus/github-action-create-milestone@master
+        if: ${{ env.do_milestones == 1 }}
+        uses: WyriHaximus/github-action-create-milestone@v1.2.0
         with:
           title: "${{ steps.nextversion.outputs.v_major }}"
         env:

--- a/.github/workflows/do-update-authors.yml
+++ b/.github/workflows/do-update-authors.yml
@@ -1,4 +1,3 @@
----
 name: Update AUTHORS.rst
 
 # What this workflow does:
@@ -77,7 +76,7 @@ jobs:
         if: success()
         with:
           add: AUTHORS.rst
-          message: Update AUTHORS.rst file with new author(s)
+          message: 'chore: update AUTHORS.rst file with new author(s)'
           author_name: GitHub Actions
           author_email: action@github.com
           committer_name: GitHub Actions

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -2,16 +2,22 @@
 #
 # - Job 1:
 #     - Get new tag.
-#     - Update CHANGELOG.md
-#     - Update pyproject.toml and docs/source/conf.py with new version.
-#     - Set PR variables.
-#     - Cut PR to merge files and create release/* branch.
+#     - Build new release.
+#     - If release candidate tag:
+#         - Cut PR to merge files and create release/* branch.
+#         - Generate GitHub (pre-)release if build succeeds.
+#         - Upload wheel to GitHub (pre-)release if build succeeds.
+#     - If release tag:
+#         - Update CHANGELOG.md
+#         - Upload wheel to Test PyPi if build succeeds. (Future)
+#         - Test install from Test PyPi. (Future)
+#         - Upload wheel to PyPi if test install succeeds. (Future)
 name: Push Version Tag Workflow
 
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.rc[0-9]+'
 
 jobs:
   request-release:
@@ -19,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: master
@@ -28,12 +34,60 @@ jobs:
         id: newversion
         run: |
           new_tag=${GITHUB_REF/refs\/tags\//}
-          echo "::set-output name=new_version::$(echo $new_tag)"
+          echo "new_tag=$(echo $new_tag)" >> $GITHUB_OUTPUT
+          echo "new_version=$(echo $new_tag | sed 's/.rc[0-9]*//')" >> $GITHUB_OUTPUT
           echo "New tag is: $new_tag"
+          echo "New version is: $new_version"
           echo "GitHub ref: ${{ github.ref }}"
+
+      - name: Build release
+        id: build
+        run: |
+          pip install -U pip poetry twine
+          poetry build && twine check dist/* && echo "build_ok=1" >> $GITHUB_ENV
+
+      - name: Open release pull request
+        uses: peter-evans/create-pull-request@v3
+        if: contains( steps.newversion.output.new_tag, 'rc' )
+        with:
+          commit-message: "release: ${{ steps.newversion.outputs.new_version }}"
+          title: "release: ${{ steps.newversion.outputs.new_version }}"
+          body: "Please cut release ${{ steps.newversion.outputs.new_version }}"
+          branch: "release/${{ steps.newversion.outputs.new_version }}"
+          base: master
+          labels: release
+
+      - name: Cut the pre-release
+        id: cutprerelease
+        if: ${{ contains( steps.newversion.output.new_tag, 'rc' ) && env.build_ok == 1 }}
+        uses: release-drafter/release-drafter@v5
+        with:
+          name: "v${{ steps.relversion.outputs.new_tag }}"
+          tag: "v${{ steps.relversion.outputs.new_tag }}"
+          version: "${{ steps.relversion.outputs.new_tag }}"
+          prerelease: true
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print release candidate info
+        run: |
+          echo ${{ steps.cutprerelease.outputs.id }}
+          echo ${{ steps.cutprerelease.outputs.name }}
+          echo ${{ steps.cutprerelease.outputs.tag_name }}
+          echo ${{ steps.cutprerelease.outputs.html_url }}
+          echo ${{ steps.cutprerelease.outputs.upload_url }}
+
+      - name: Upload wheel to GitHub release
+        id: upload-wheel
+        if: ${{ contains( steps.newversion.output.new_tag, 'rc' ) && env.build_ok == 1 }}
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.cutprerelease.outputs.upload_url }}
 
       - name: Generate release changelog
         uses: heinrichreimer/github-changelog-generator-action@master
+        if: ${{ !contains( steps.newversion.output.new_tag, 'rc' ) && env.build_ok == 1 }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sinceTag: "v1.3.1"
@@ -41,9 +95,9 @@ jobs:
           breakingLabel: "Breaking Changes"
           breakingLabels: "V: major"
           enhancementLabel: "New Features"
-          enhancementLabels: "V: minor"
+          enhancementLabels: "P: enhancement"
           bugsLabel: "Bug Fixes"
-          bugLabels: "V: patch"
+          bugLabels: "P: bug"
           excludeLabels: "release"
           issues: false
           issuesWoLabels: false
@@ -56,21 +110,26 @@ jobs:
           stripGeneratorNotice: true
           verbose: true
 
-      - name: Update pyproject.toml and docs/conf.py
-        uses: vemel/nextversion@main
-        with:
-          path: ./pyproject.toml
-          result: ${{ steps.newversion.outputs.new_version }}
-          update: |
-            ./pyproject.toml
-            ./docs/source/conf.py
+#      - name: Publish to Test PyPi
+#        if: ${{ !contains( steps.newversion.output.new_tag, 'rc' ) && env.build_ok == 1 }}
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          user: __token__
+#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+#          repository_url: https://test.pypi.org/legacy/
 
-      - name: Request release pull request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: "release: ${{ steps.newversion.outputs.new_version }}"
-          title: "release: ${{ steps.newversion.outputs.new_version }}"
-          body: "Please cut release ${{ steps.newversion.outputs.new_version }}"
-          branch: "release/${{ steps.newversion.outputs.new_version }}"
-          base: master
-          labels: release
+#      - name: Test install from Test PyPI
+#        if: ${{ !contains( steps.newversion.output.new_tag, 'rc' ) && env.build_ok == 1 }}
+#        run: |
+#          sudo apt-get update
+#          pip install \
+#          --index-url https://test.pypi.org/simple/ \
+#          --extra-index-url https://pypi.org/simple \
+#          docformatter==${{ steps.newversion.outputs.new_version }} && echo "install_ok=1" >> $GITHUB_ENV
+
+#      - name: Publish to PyPi
+#        if: ${{ !contains( steps.newversion.output.new_tag, 'rc' ) && env.install_ok == 1 }}
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          user: __token__
+#          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Updates action versions.
Changes commit message to conventional commit format for action to update AUTHORS.rst.
Add steps to create GitHub (pre-)release when release candidate tag is pushed and upload wheel to release.
Move steps to upload wheels and test install on release tags to tags action.