### PR TITLE
fix: remove blank lines after line beginning with 'def'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,3 @@ jobs:
         run: tox -vv --notest
       - name: Run tests with tox
         run: tox -e py --skip-pkg-install
-      - name: Create Coveralls coverage report
-        uses: miurahr/coveralls-python-action@patch-pyprject-toml
-        with:
-          base-path: .tox
-          debug: true
-          parallel: true
-
-  upload_coveralls:
-    name: Upload Results to Coveralls
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Upload coverage report to Coveralls
-        uses: miurahr/coveralls-python-action@patch-pyprject-toml
-        with:
-          base-path: .tox
-          debug: true
-          parallel-finished: true

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -118,9 +118,10 @@ with the following ``.pre-commit-config.yaml`` configuration:
 .. code-block:: yaml
 
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.5.0
+    rev: v1.6.1
     hooks:
       - id: docformatter
+        additional_dependencies: [tomli]
         args: [--in-place --config ./pyproject.toml]
 
 You will need to install ``pre-commit`` and run ``pre-commit install``.
@@ -130,6 +131,9 @@ will fail if ``docformatter`` processes a change.  The ``--in-place`` option
 fails because pre-commit does a diff check and fails if it detects a hook
 changed a file.  The ``--check`` option fails because ``docformatter`` returns
 a non-zero exit code.
+
+The ``additional_dependencies: [tomli]`` is only required if you are using
+``pyproject.toml`` for ``docformatter``'s configuration.
 
 Use with GitHub Actions
 -----------------------

--- a/src/docformatter/__init__.py
+++ b/src/docformatter/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/__main__.py
+++ b/src/docformatter/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/__pkginfo__.py
+++ b/src/docformatter/__pkginfo__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/configuration.py
+++ b/src/docformatter/configuration.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/encode.py
+++ b/src/docformatter/encode.py
@@ -28,7 +28,7 @@ import collections
 import io
 import locale
 import sys
-from typing import Dict
+from typing import Dict, List
 
 # Third Party Imports
 from charset_normalizer import from_path  # pylint: disable=import-error
@@ -67,7 +67,7 @@ class Encoder:
         except (SyntaxError, LookupError, UnicodeDecodeError):
             self.encoding = "latin-1"
 
-    def do_find_newline(self, source: str) -> Dict[int, int]:
+    def do_find_newline(self, source: List[str]) -> Dict[int, int]:
         """Return type of newline used in source.
 
         Parameters

--- a/src/docformatter/encode.py
+++ b/src/docformatter/encode.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/format.py
+++ b/src/docformatter/format.py
@@ -229,13 +229,13 @@ class Formatter:
             The text from the source file.
         """
         try:
-            original_newline = self.encodor.do_find_newline(
+            _original_newline = self.encodor.do_find_newline(
                 source.splitlines(True)
             )
-            code = self._format_code(source)
+            _code = self._format_code(source)
 
             return _strings.normalize_line_endings(
-                code.splitlines(True), original_newline
+                _code.splitlines(True), _original_newline
             )
         except (tokenize.TokenError, IndentationError):
             return source
@@ -322,7 +322,7 @@ class Formatter:
                     not in {tokenize.NL, tokenize.NEWLINE}
                     or modified_tokens[-2][1] != ":"
                     and modified_tokens[-2][0] != tokenize.COMMENT
-                    or not modified_tokens[-2][4].lstrip().startswith(("def"))
+                    or not modified_tokens[-2][4].lstrip().startswith("def ")
                 ):
                     modified_tokens.append(
                         (token_type, token_string, start, end, line)

--- a/src/docformatter/format.py
+++ b/src/docformatter/format.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/strings.py
+++ b/src/docformatter/strings.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -325,9 +325,7 @@ def do_split_description(
         # If the text including the URL is longer than the wrap length,
         # we need to split the description before the URL, wrap the pre-URL
         # text, and add the URL as a separate line.
-        if len(text[_text_idx : _idx[1]]) > (
-            wrap_length - len(indentation)
-        ):
+        if len(text[_text_idx : _idx[1]]) > (wrap_length - len(indentation)):
             # Wrap everything in the description before the first URL.
             _lines.extend(
                 description_to_list(

--- a/src/docformatter/util.py
+++ b/src/docformatter/util.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@
 #
 #       tests._init__.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 #
 #       tests.conftest.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_configuration_functions.py
+++ b/tests/test_configuration_functions.py
@@ -4,7 +4,7 @@
 #       tests.test_configuration_functions.py is part of the docformatter
 #       project
 #
-# Copyright (C) 2012-2022 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_docformatter.py
+++ b/tests/test_docformatter.py
@@ -3,7 +3,7 @@
 #
 #       tests.test_docformatter.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_encoding_functions.py
+++ b/tests/test_encoding_functions.py
@@ -3,7 +3,7 @@
 #
 #       tests.test_encoding_functions.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_format_code.py
+++ b/tests/test_format_code.py
@@ -3,7 +3,7 @@
 #
 #       tests.test_format_code.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -3,7 +3,7 @@
 #
 #       tests.test_format_docstring.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -24,7 +24,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Module for testing the format_docstring() function."""
+"""Module for testing the Formatter class."""
 
 
 # Standard Library Imports
@@ -330,6 +330,41 @@ Hello.
     """'''
         assert docstring == uut._do_format_docstring(INDENTATION, docstring)
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize("args", [[""]])
+    def test_format_docstring_leave_blank_line_after_variable_def(self,
+                                                                  test_args,
+                                                                  args,):
+        """Leave blank lines after any variable beginning with 'def'.
+
+        See issue #156.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '\
+class AcceptHeader(ExtendedSchemaNode): \
+    # ok to use name in this case because target key in the mapping must \
+    # be that specific value but cannot have a field named with this format \
+    name = "Accept" \
+    schema_type = String \
+    missing = drop \
+    default = ContentType.APP_JSON  # defaults to JSON for easy use within browsers \
+\
+\
+class AcceptLanguageHeader(ExtendedSchemaNode): \
+    # ok to use name in this case because target key in the mapping must \
+    # be that specific value but cannot have a field named with this format \
+    name = "Accept-Language" \
+    schema_type = String \
+    missing = drop \
+    default = AcceptLanguage.EN_CA \
+    # FIXME: oneOf validator for supported languages (?)'
+        assert docstring == uut._do_format_code(docstring)
 
 class TestFormatLists:
     """Class for testing format_docstring() with lists in the docstring."""

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -3,7 +3,7 @@
 #
 #       tests.test_utility_functions.py is part of the docformatter project
 #
-# Copyright (C) 2012-2019 Steven Myint
+# Copyright (C) 2012-2023 Steven Myint
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the


### PR DESCRIPTION
Fixes problem with blank lines between methods/functions being removed when the last line in the first function began with "def".

Closes #156 
Closes #165
Closes #172
Closes #173