### PR TITLE
fix: remove blank after comment

### DIFF
--- a/src/docformatter/format.py
+++ b/src/docformatter/format.py
@@ -29,6 +29,7 @@ import argparse
 import collections
 import contextlib
 import io
+import re
 import tokenize
 from typing import TextIO, Tuple
 
@@ -587,11 +588,15 @@ class Formatter:
                 ].strip().startswith(
                     '"""'
                 )
+                _comment_follows = re.search(
+                    r"\"\"\" *#", modified_tokens[_idx - 4][4]
+                )
 
                 if (
                     _token[0] == 1
                     and not _is_definition
                     and not _is_docstring
+                    and not _comment_follows
                     and _after_definition
                     and _after_docstring
                 ):

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -366,6 +366,49 @@ class AcceptLanguageHeader(ExtendedSchemaNode): \
     # FIXME: oneOf validator for supported languages (?)'
         assert docstring == uut._do_format_code(docstring)
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize("args", [[""]])
+    def test_format_docstring_leave_blank_line_after_comment(self,
+                                                                  test_args,
+                                                                  args,):
+        """Leave blank lines after docstring followed by a comment.
+
+        See issue #176.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+def Class1:
+    """Class.""" #noqa
+
+    attribute
+    """Attr."""
+
+
+def Class2:
+    """Class."""
+
+    attribute
+    """Attr."""
+
+
+def Class3:
+    """Class docstring.
+
+    With long description.
+    """    #noqa
+
+    attribute
+    """Attr."""
+'''
+        assert docstring == uut._do_format_code(docstring)
+
+
 class TestFormatLists:
     """Class for testing format_docstring() with lists in the docstring."""
 


### PR DESCRIPTION
Fixes problem with docformatter removing the blank following a class docstring when the docstring is followed by a comment.

Closes #176.