### PR TITLE
fix: wrapping issues with reST directives, quoted URLs, and Sphinx field lists

### DIFF
--- a/.github/workflows/do-prioritize-issues.yml
+++ b/.github/workflows/do-prioritize-issues.yml
@@ -24,19 +24,22 @@ jobs:
         uses: weibullguy/get-labels-action@main
 
       - name: Add High Urgency Labels
-        if: (endsWith(steps.getlabels.outputs.labels, 'convention') && endsWith(steps.getlabels.outputs.labels, 'bug'))
+        if: |
+          ${{ (contains(steps.getlabels.outputs.labels, "C: convention") && contains (steps.getlabels.outputs.labels, "P: bug")) }}
         uses: andymckay/labeler@master
         with:
           add-labels: "U: high"
 
       - name: Add Medium Urgency Labels
-        if: (endsWith(steps.getlabels.outputs.labels, 'style') && endsWith(steps.getlabels.outputs.labels, 'bug')) || (endsWith(steps.getlabels.outputs.labels, 'stakeholder') && endsWith(steps.getlabels.outputs.labels, 'bug')) || (endsWith(steps.getlabels.outputs.labels, 'convention') && endsWith(steps.getlabels.outputs.labels, 'enhancement'))
+        if: |
+          ${{ (contains(steps.getlabels.outputs.labels, "C: style") && contains(steps.getlabels.outputs.labels, "P: bug")) || (contains(steps.getlabels.outputs.labels, "C: stakeholder") && contains(steps.getlabels.outputs.labels, "P: bug")) || (contains(steps.getlabels.outputs.labels, "C: convention") && contains(steps.getlabels.outputs.labels, "P: enhancement")) }}
         uses: andymckay/labeler@master
         with:
           add-labels: "U: medium"
 
       - name: Add Low Urgency Labels
-        if: (endsWith(steps.getlabels.outputs.labels, 'style') && endsWith(steps.getlabels.outputs.labels, 'enhancement')) || (endsWith(steps.getlabels.outputs.labels, 'stakeholder') && endsWith(steps.getlabels.outputs.labels, 'enhancement')) || contains(steps.getlabels.outputs.labels, 'doc') || contains(steps.getlabels.outputs.labels, 'chore')
+        if: |
+          ${{ (contains(steps.getlabels.outputs.labels, "C: style") && contains(steps.getlabels.outputs.labels, "P: enhancement")) || (contains(steps.getlabels.outputs.labels, "C: stakeholder") && contains(steps.getlabels.outputs.labels, "P: enhancement")) || contains(steps.getlabels.outputs.labels, "doc") || contains(steps.getlabels.outputs.labels, "chore") }}
         uses: andymckay/labeler@master
         with:
           add-labels: "U: low"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,13 @@ repos:
         - id: isort
           args: [--settings-file, ./pyproject.toml]
     - repo: https://github.com/PyCQA/docformatter
-      rev: v1.7.0
+      rev: v1.7.1
       hooks:
         - id: docformatter
           additional_dependencies: [tomli]
           args: [--in-place, --config, ./pyproject.toml]
     - repo: https://github.com/charliermarsh/ruff-pre-commit
-      rev: 'v0.0.267'
+      rev: 'v0.0.269'
       hooks:
         - id: ruff
           args: [ --select, "PL", --select, "F" ]

--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -555,7 +555,7 @@ def do_wrap_urls(
             _text = f"{text[_url[0]: _url[1]]}"
             with contextlib.suppress(IndexError):
                 if _lines[0][-1] == '"':
-                    _lines[0] = _lines[0][:-1]
+                    _lines[0] = _lines[0][:-2]
                     _text = f'"{text[_url[0] : _url[1]]}'
 
             _lines.append(f"{do_clean_url(_text, indentation)}")

--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -51,7 +51,7 @@ NUMPY_REGEX = r"^\s[a-zA-Z0-9_\- ]+ ?: [\S ]+"
 OPTION_REGEX = r"^-{1,2}[\S ]+ {2}\S+"
 """Regular expression to use for finding option lists."""
 
-REST_REGEX = r"(\.{2}|``) ?[\w-]+(:{1,2}|``)?"
+REST_REGEX = r"((\.{2}|`{2}) ?[\w.~-]+(:{2}|`{2})?[\w ]*?|`[\w.~]+`)"
 """Regular expression to use for finding reST directives."""
 
 SPHINX_REGEX = r":[a-zA-Z0-9_\- ]*:"

--- a/tests/test_format_docstring.py
+++ b/tests/test_format_docstring.py
@@ -935,6 +935,60 @@ num_iterations is the number of updates - instead of a better definition of conv
         )
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("args", [[""]])
+    def test_format_docstring_with_class_attributes(self, test_args, args):
+        """Wrap long class attribute docstrings."""
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+class TestClass:
+    """This is a class docstring."""
+
+    test_int = 1
+    """This is a very, very, very long docstring that should really be
+    reformatted nicely by docformatter."""
+'''
+        assert docstring == uut._do_format_code(
+            '''\
+class TestClass:
+    """This is a class docstring."""
+
+    test_int = 1
+    """This is a very, very, very long docstring that should really be reformatted nicely by docformatter."""
+'''
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("args", [[""]])
+    def test_format_docstring_no_newline_in_summary_with_symbol(self, test_args, args):
+        """Wrap summary with symbol should not add newline.
+
+        See issue #79.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        docstring = '''\
+def function2():
+    """Hello yeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeet
+    -v."""
+'''
+        assert docstring == uut._do_format_code(docstring)
+
+
+class TestFormatWrapURL:
+    """Class for testing _do_format_docstring() with line wrapping and URLs."""
+
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "args",
         [["--wrap-descriptions", "72", ""]],
@@ -1472,39 +1526,10 @@ __ https://sw.kovidgoyal.net/kitty/graphics-protocol/
 
     @pytest.mark.unit
     @pytest.mark.parametrize("args", [[""]])
-    def test_format_docstring_with_class_attributes(self, test_args, args):
-        """Wrap long class attribute docstrings."""
-        uut = Formatter(
-            test_args,
-            sys.stderr,
-            sys.stdin,
-            sys.stdout,
-        )
+    def test_format_docstring_with_quoted_link(self, test_args, args):
+        """Anonymous link references should not be wrapped into the link.
 
-        docstring = '''\
-class TestClass:
-    """This is a class docstring."""
-
-    test_int = 1
-    """This is a very, very, very long docstring that should really be
-    reformatted nicely by docformatter."""
-'''
-        assert docstring == uut._do_format_code(
-            '''\
-class TestClass:
-    """This is a class docstring."""
-
-    test_int = 1
-    """This is a very, very, very long docstring that should really be reformatted nicely by docformatter."""
-'''
-        )
-
-    @pytest.mark.unit
-    @pytest.mark.parametrize("args", [[""]])
-    def test_format_docstring_no_newline_in_summary_with_symbol(self, test_args, args):
-        """Wrap summary with symbol should not add newline.
-
-        See issue #79.
+        See issue #218.
         """
         uut = Formatter(
             test_args,
@@ -1514,11 +1539,32 @@ class TestClass:
         )
 
         docstring = '''\
-def function2():
-    """Hello yeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeet
-    -v."""
+"""Construct a candidate project URL from the bundle and app name.
+
+It's not a perfect guess, but it's better than having
+"https://example.com".
+
+:param bundle: The bundle identifier.
+:param app_name: The app name.
+:returns: The candidate project URL
+"""
 '''
-        assert docstring == uut._do_format_code(docstring)
+        assert docstring == uut._do_format_code(
+            '''\
+"""Construct a candidate project URL from the bundle and app name.
+
+It's not a perfect guess, but it's better than having "https://example.com".
+
+:param bundle: The bundle identifier.
+:param app_name: The app name.
+:returns: The candidate project URL
+"""
+'''
+        )
+
+
+class TestFormatWrapBlack:
+    """Class for testing _do_format_docstring() with line wrapping and black option."""
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -1584,6 +1630,10 @@ This long description will be wrapped at 88 characters because we passed the --b
 ''',
             )
         )
+
+
+class TestFormatWrapEpytext:
+    """Class for testing _do_format_docstring() with line wrapping and Epytext lists."""
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -1720,6 +1770,10 @@ This long description will be wrapped at 88 characters because we passed the --b
             )
         )
 
+
+class TestFormatWrapSphinx:
+    """Class for testing _do_format_docstring() with line wrapping and Sphinx lists."""
+
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "args",
@@ -1853,6 +1907,118 @@ This long description will be wrapped at 88 characters because we passed the --b
     :return: really long description text wrapped at n characters and a very long description of the return value so we can wrap this line abcd efgh ijkl mnop qrst uvwx yz.
     :rtype: str
 """\
+''',
+            )
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "--wrap-descriptions",
+                "88",
+                "--wrap-summaries",
+                "88",
+                "",
+            ]
+        ],
+    )
+    def test_format_docstring_sphinx_style_remove_excess_whitespace(
+        self,
+        test_args,
+        args,
+    ):
+        """Should remove unneeded whitespace.
+
+        See issue #217
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        assert (
+            (
+                '''\
+"""Base for all Commands.
+
+    :param logger: Logger for console and logfile.
+    :param console: Facilitates console interaction and input solicitation.
+    :param tools: Cache of tools populated by Commands as they are required.
+    :param apps: Dictionary of project's Apps keyed by app name.
+    :param base_path: Base directory for Briefcase project.
+    :param data_path: Base directory for Briefcase tools, support packages, etc.
+    :param is_clone: Flag that Command was triggered by the user's requested Command;
+        for instance, RunCommand can invoke UpdateCommand and/or BuildCommand.
+    """\
+'''
+            )
+            == uut._do_format_docstring(
+                INDENTATION,
+                '''\
+"""Base for all Commands.
+
+:param logger: Logger for console and logfile.
+:param console: Facilitates console interaction and input solicitation.
+:param tools: Cache of tools populated by Commands as they are required.
+:param apps: Dictionary of project's Apps keyed by app name.
+:param base_path: Base directory for Briefcase project.
+:param data_path: Base directory for Briefcase tools, support packages, etc.
+:param is_clone: Flag that Command was triggered by the user's requested Command;
+    for instance, RunCommand can invoke UpdateCommand and/or BuildCommand.
+"""\
+''',
+            )
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "--wrap-descriptions",
+                "88",
+                "--wrap-summaries",
+                "88",
+                "",
+            ]
+        ],
+    )
+    def test_format_docstring_sphinx_style_two_directives_in_row(
+        self,
+        test_args,
+        args,
+    ):
+        """Should remove unneeded whitespace.
+
+        See issue #215.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        assert (
+            (
+                '''\
+"""Create or return existing HTTP session.
+
+    :return: Requests :class:`~requests.Session` object
+    """\
+'''
+            )
+            == uut._do_format_docstring(
+                INDENTATION,
+                '''\
+"""Create or return existing HTTP session.
+
+    :return: Requests :class:`~requests.Session` object
+    """\
 ''',
             )
         )


### PR DESCRIPTION
Fixes the problem with reST directives being split up when they contain two words surrounded by colons (#215).
Fixes the problem with quoted URLs being wrapped after the opening quote (#217).
Fixes the problem with Sphinx field lists not having all the white space removed before wrapping (#218).

Closes #215 
Closes #217 
Closes #218 