### PR TITLE
chore: move changelog to tag workflow

### DIFF
--- a/.github/workflows/do-prioritize-issues.yml
+++ b/.github/workflows/do-prioritize-issues.yml
@@ -24,19 +24,19 @@ jobs:
         uses: weibullguy/get-labels-action@main
 
       - name: Add High Urgency Labels
-        if: '${{ (contains(steps.getlabels.outputs.labels, "C: convention") && contains (steps.getlabels.outputs.labels, "P: bug")) }}'
+        if: "${{ (contains(steps.getlabels.outputs.labels, 'C: convention') && contains (steps.getlabels.outputs.labels, 'P: bug')) }}"
         uses: andymckay/labeler@master
         with:
           add-labels: "U: high"
 
       - name: Add Medium Urgency Labels
-        if: '${{ (contains(steps.getlabels.outputs.labels, "C: style") && contains(steps.getlabels.outputs.labels, "P: bug")) || (contains(steps.getlabels.outputs.labels, "C: stakeholder") && contains(steps.getlabels.outputs.labels, "P: bug")) || (contains(steps.getlabels.outputs.labels, "C: convention") && contains(steps.getlabels.outputs.labels, "P: enhancement")) }}'
+        if: "${{ (contains(steps.getlabels.outputs.labels, 'C: style') && contains(steps.getlabels.outputs.labels, 'P: bug')) || (contains(steps.getlabels.outputs.labels, 'C: stakeholder') && contains(steps.getlabels.outputs.labels, 'P: bug')) || (contains(steps.getlabels.outputs.labels, 'C: convention') && contains(steps.getlabels.outputs.labels, 'P: enhancement')) }}"
         uses: andymckay/labeler@master
         with:
           add-labels: "U: medium"
 
       - name: Add Low Urgency Labels
-        if: '${{ (contains(steps.getlabels.outputs.labels, "C: style") && contains(steps.getlabels.outputs.labels, "P: enhancement")) || (contains(steps.getlabels.outputs.labels, "C: stakeholder") && contains(steps.getlabels.outputs.labels, "P: enhancement")) || contains(steps.getlabels.outputs.labels, "doc") || contains(steps.getlabels.outputs.labels, "chore") }}'
+        if: "${{ (contains(steps.getlabels.outputs.labels, 'C: style') && contains(steps.getlabels.outputs.labels, 'P: enhancement')) || (contains(steps.getlabels.outputs.labels, 'C: stakeholder') && contains(steps.getlabels.outputs.labels, 'P: enhancement')) || contains(steps.getlabels.outputs.labels, 'doc') || contains(steps.getlabels.outputs.labels, 'chore') }}"
         uses: andymckay/labeler@master
         with:
           add-labels: "U: low"

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -41,50 +41,6 @@ jobs:
           echo "version=$(echo $(poetry version | cut -d' ' -f2))" >> $GITHUB_OUTPUT
           echo "do_release=1" >> $GITHUB_ENV
 
-      - name: Generate release changelog
-        uses: heinrichreimer/github-changelog-generator-action@master
-        if: ${{ env.do_release == 1 }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sinceTag: "v1.3.1"
-          excludeTagsRegex: "-rc[0-9]"
-          breakingLabel: "Breaking Changes"
-          breakingLabels: "V: major"
-          enhancementLabel: "Features"
-          enhancementLabels: "P: enhancement"
-          bugsLabel: "Bug Fixes"
-          bugLabels: "P: bug"
-          excludeLabels: "release"
-          issues: false
-          issuesWoLabels: false
-          maxIssues: 100
-          pullRequests: true
-          prWoLabels: false
-          author: true
-          unreleased: true
-          compareLink: true
-          stripGeneratorNotice: true
-          verbose: true
-
-      - name: Check if diff
-        if: ${{ env.do_release == 1 }}
-        continue-on-error: true
-        run: >
-          git diff --exit-code CHANGELOG.md &&
-          (echo "### No update" && exit 1) || (echo "### Commit update")
-
-      - uses: EndBug/add-and-commit@v9
-        name: Commit and push if diff
-        if: ${{ env.do_release == 1 }}
-        with:
-          add: CHANGELOG.md
-          message: 'chore: update CHANGELOG.md for new release'
-          author_name: GitHub Actions
-          author_email: action@github.com
-          committer_name: GitHub Actions
-          committer_email: actions@github.com
-          push: true
-
       - name: Build release
         id: build
         if: ${{ env.do_release == 1 }}

--- a/.github/workflows/on-push-tag.yml
+++ b/.github/workflows/on-push-tag.yml
@@ -14,6 +14,74 @@ on:
       - 'v*'
 
 jobs:
+  update_changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Get new tag
+        id: newversion
+        run: |
+          tag=${GITHUB_REF/refs\/tags\//}
+          version=$(echo $tag | sed 's/-rc[0-9]*//')
+          if [[ $tag != *"-rc"* ]]; then
+            echo "do_changelog=1" >> $GITHUB_ENV
+            echo "tag=$(echo $tag)" >> $GITHUB_OUTPUT
+            echo "version=$(echo $version)" >> $GITHUB_OUTPUT
+          fi
+          echo "New tag is: $tag"
+          echo "New version is: $version"
+          echo "GitHub ref: ${{ github.ref }}"
+
+      - name: Generate release changelog
+        uses: heinrichreimer/github-changelog-generator-action@master
+        if: ${{ env.do_changelog == 1 }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sinceTag: "v1.3.1"
+          excludeTagsRegex: "-rc[0-9]"
+          breakingLabel: "Breaking Changes"
+          breakingLabels: "V: major"
+          enhancementLabel: "Features"
+          enhancementLabels: "P: enhancement"
+          bugsLabel: "Bug Fixes"
+          bugLabels: "P: bug"
+          excludeLabels: "release"
+          issues: false
+          issuesWoLabels: false
+          maxIssues: 100
+          pullRequests: true
+          prWoLabels: false
+          author: true
+          unreleased: true
+          compareLink: true
+          stripGeneratorNotice: true
+          verbose: true
+
+      - name: Check if diff
+        if: ${{ env.do_changelog == 1 }}
+        continue-on-error: true
+        run: >
+          git diff --exit-code CHANGELOG.md &&
+          (echo "### No update" && exit 1) || (echo "### Commit update")
+
+      - uses: EndBug/add-and-commit@v9
+        name: Commit and push if diff
+        if: ${{ env.do_changelog == 1 }}
+        with:
+          add: CHANGELOG.md
+          message: 'chore: update CHANGELOG.md for new release'
+          author_name: GitHub Actions
+          author_email: action@github.com
+          committer_name: GitHub Actions
+          committer_email: actions@github.com
+          push: true
+
   manage_milestones:
     name: Manage Milestones
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move the job to autogenerate the CHANGELOG.md to the tag work flow instead of the release workflow.  Need the tag to keep the CHANGELOG.md up to date and the release workflow comes before the tag.