### PR TITLE
Add pre-commit example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,22 @@ gets formatted into this
         if factorial(10):
             launch_rocket()
 
+
+Pre-commit hook
+===============
+
+Add docformatter to your ``.prepre-commit-config.yaml`` as follows.
+
+.. code-block:: yaml
+
+    - repo: https://github.com/PyCQA/docformatter
+      rev: v1.7.1
+      hooks:
+        - id: docformatter
+          additional_dependencies: [tomli]
+          args: [--in-place, --config, ./pyproject.toml]
+
+
 Marketing
 =========
 Do you use *docformatter*?  What style docstrings do you use?  Add some badges to your project's **README** and let everyone know.


### PR DESCRIPTION
I was trying to figure out how to add docformatter to my pre-commit config, and thought I'd save someone else the trouble by including an example.