### PR TITLE
fix: summary with back ticks and sphinx field names with periods

### DIFF
--- a/src/docformatter/format.py
+++ b/src/docformatter/format.py
@@ -479,7 +479,6 @@ class Formatter:
                 self.args.rest_section_adorns,
                 self.args.style,
             )
-            or _syntax.do_find_directives(summary)
             or _syntax.do_find_links(summary)
         ):
             # Something is probably not right with the splitting.

--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -59,7 +59,7 @@ OPTION_REGEX = r"^-{1,2}[\S ]+ {2}\S+"
 REST_REGEX = r"((\.{2}|`{2}) ?[\w.~-]+(:{2}|`{2})?[\w ]*?|`[\w.~]+`)"
 """Regular expression to use for finding reST directives."""
 
-SPHINX_REGEX = r":[a-zA-Z0-9_\-() ]*:"
+SPHINX_REGEX = r":[a-zA-Z0-9_\-(). ]*:"
 """Regular expression to use for finding Sphinx-style field lists."""
 
 URL_PATTERNS = (

--- a/tests/_data/string_files/do_format_code.toml
+++ b/tests/_data/string_files/do_format_code.toml
@@ -302,3 +302,14 @@ from typing import Iterator
 """Don't remove this comment, it's cool."""
 IMPORTANT_CONSTANT = "potato"
 '''
+
+[issue_243]
+instring='''def foo(bar):
+    """Return `foo` using `bar`. Description."""
+'''
+outstring='''def foo(bar):
+    """Return `foo` using `bar`.
+
+    Description.
+    """
+'''

--- a/tests/_data/string_files/format_sphinx.toml
+++ b/tests/_data/string_files/format_sphinx.toml
@@ -212,3 +212,14 @@ outstring='''"""Summary.
 
     :param param: asdf
     """'''
+
+[issue_245]
+instring='''"""Some f.
+    :param a: Some param.
+    :raises my.package.MyReallySrsError: Bad things happened.
+    """'''
+outstring='''"""Some f.
+
+    :param a: Some param.
+    :raises my.package.MyReallySrsError: Bad things happened.
+    """'''

--- a/tests/_data/string_files/format_urls.toml
+++ b/tests/_data/string_files/format_urls.toml
@@ -227,8 +227,8 @@ instring='''"""Locate and call the ``mpm`` CLI.
     """'''
 outstring='''"""Locate and call the ``mpm`` CLI.
 
-    The output must supports both `Xbar dialect
-    <https://github.com/matryer/xbar-plugins/blob/main/CONTRIBUTING.md#plugin-api>`_
+    The output must supports both
+    `Xbar dialect <https://github.com/matryer/xbar-plugins/blob/main/CONTRIBUTING.md#plugin-api>`_
     and `SwiftBar dialect <https://github.com/swiftbar/SwiftBar#plugin-api>`_.
     """'''
 
@@ -288,8 +288,7 @@ def sub_func_test():
 
 [issue_157_8]
 instring='''def mixed_links():
-    """Implements the minimal code necessary to locate and call the ``mpm`` CLI on the
-    system.
+    """Implements the minimal code necessary to locate and call the ``mpm`` CLI on the system.
 
     Once ``mpm`` is located, we can rely on it to produce the main output of the plugin.
 
@@ -331,8 +330,8 @@ By default we choose to exclude:
   options set.
 """'''
 outstring='''def mixed_links():
-    """Implements the minimal code necessary to locate and call the ``mpm`` CLI on the
-    system.
+    """Implements the minimal code necessary to locate and call the ``mpm`` CLI
+    on the system.
 
     Once ``mpm`` is located, we can rely on it to produce the main output of the plugin.
 

--- a/tests/formatter/test_do_format_code.py
+++ b/tests/formatter/test_do_format_code.py
@@ -420,3 +420,28 @@ class TestDoFormatCode:
         assert outstring == uut._do_format_code(
             instring,
         )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("args", [[""]])
+    def test_format_code_with_backtick_in_summary(
+        self,
+        test_args,
+        args,
+    ):
+        """Format docstring with summary containing backticks.
+
+        See issue #243.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        instring = self.TEST_STRINGS["issue_243"]["instring"]
+        outstring = self.TEST_STRINGS["issue_243"]["outstring"]
+
+        assert outstring == uut._do_format_code(
+            instring,
+        )

--- a/tests/formatter/test_format_sphinx.py
+++ b/tests/formatter/test_format_sphinx.py
@@ -359,3 +359,40 @@ class TestFormatWrapSphinx:
             INDENTATION,
             instring,
         )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "--wrap-descriptions",
+                "88",
+                "--wrap-summaries",
+                "88",
+                "",
+            ]
+        ],
+    )
+    def test_format_docstring_sphinx_style_field_name_has_periods(
+        self,
+        test_args,
+        args,
+    ):
+        """Should format sphinx field names containing a period.
+
+        See issue #245.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        instring = self.TEST_STRINGS["issue_245"]["instring"]
+        outstring = self.TEST_STRINGS["issue_245"]["outstring"]
+
+        assert outstring == uut._do_format_docstring(
+            INDENTATION,
+            instring,
+        )


### PR DESCRIPTION
Fixes not formatting docstrings with a summary containing back ticks and Sphinx-style field names containing periods.

Closes #243 
Closes #245