### PR TITLE
fix: resolve configuration file precedence issue

### DIFF
--- a/src/docformatter/configuration.py
+++ b/src/docformatter/configuration.py
@@ -87,9 +87,18 @@ class Configurater:
             self.config_file = self.args_lst[self.args_lst.index("--config") + 1]
         except ValueError:
             for _configuration_file in self.configuration_file_lst:
-                if os.path.isfile(_configuration_file):
-                    self.config_file = f"./{_configuration_file}"
-                    break
+                _config_section: str = (
+                    "[tool.docformatter]"
+                    if _configuration_file == "pyproject.toml"
+                    else "[docformatter]"
+                )
+                _config_file_path: str = f"./{_configuration_file}"
+                if os.path.isfile(_config_file_path):
+                    with open(_config_file_path, "r") as _config_file:
+                        _config = _config_file.read()
+                    if _config_section in _config:
+                        self.config_file = _config_file_path
+                        break
 
         if os.path.isfile(self.config_file):
             self._do_read_configuration_file()


### PR DESCRIPTION
The package searches its configuration in some standard config files following a strict order:

1. `pyproject.toml`
2. `setup.cfg`
3. `tox.ini`

That's great as enables variety of config schemes. The problem is that the searching loop is broken when it finds *the file*, not the actual configuration in it. So, if you want to define configuration in `setup.cfg`, but have other tool (e.g., `black` in my case) configured in `pyproject.toml` (or even if you define project metadata in that file, following [PEP 621](https://peps.python.org/pep-0621/)), `docformatter` does not see the desired settings.

In this PR, I propose a simple update of `configuration.Configurater` class constructor to resolve this issue.