### PR TITLE
fix: not recognizing `yield` as a sphinx field name

### DIFF
--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -59,7 +59,7 @@ OPTION_REGEX = r"^-{1,2}[\S ]+ {2}\S+"
 REST_REGEX = r"((\.{2}|`{2}) ?[\w.~-]+(:{2}|`{2})?[\w ]*?|`[\w.~]+`)"
 """Regular expression to use for finding reST directives."""
 
-SPHINX_REGEX = r":(param|raises|return|rtype|type)[a-zA-Z0-9_\-.() ]*:"
+SPHINX_REGEX = r":(param|raises|return|rtype|type|yield)[a-zA-Z0-9_\-.() ]*:"
 """Regular expression to use for finding Sphinx-style field lists."""
 
 URL_PATTERNS = (

--- a/tests/_data/string_files/format_sphinx.toml
+++ b/tests/_data/string_files/format_sphinx.toml
@@ -236,3 +236,17 @@ outstring='''"""CC.
 
     c c :math:`[0, 1]`.
     """'''
+
+[issue_253]
+instring='''"""
+    My test fixture.
+
+    :param caplog: Pytest caplog fixture.
+    :yield: Until test complete, then run cleanup.
+    """'''
+outstring='''"""
+    My test fixture.
+
+    :param caplog: Pytest caplog fixture.
+    :yield: Until test complete, then run cleanup.
+    """'''

--- a/tests/formatter/test_format_sphinx.py
+++ b/tests/formatter/test_format_sphinx.py
@@ -433,3 +433,42 @@ class TestFormatWrapSphinx:
             INDENTATION,
             instring,
         )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "args",
+        [
+            [
+                "--wrap-descriptions",
+                "120",
+                "--wrap-summaries",
+                "120",
+                "--pre-summary-newline",
+                "--black",
+                "",
+            ]
+        ],
+    )
+    def test_format_docstring_sphinx_style_recognize_yield(
+        self,
+        test_args,
+        args,
+    ):
+        """Should identify `yield` as sphinx field name.
+
+        See issue #253.
+        """
+        uut = Formatter(
+            test_args,
+            sys.stderr,
+            sys.stdin,
+            sys.stdout,
+        )
+
+        instring = self.TEST_STRINGS["issue_253"]["instring"]
+        outstring = self.TEST_STRINGS["issue_253"]["outstring"]
+
+        assert outstring == uut._do_format_docstring(
+            INDENTATION,
+            instring,
+        )


### PR DESCRIPTION
Adds `yield` to the list of sphinx field names.

Closes #253 