### PR TITLE
Add missing comma in requirements table

### DIFF
--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -169,7 +169,7 @@ the requirement falls in, the type of requirement, and whether
     ' docformatter_4.5.2', ' One-line docstrings will have the first word capitalized.', ' Derived', ' Shall', ' Yes'
     ' docformatter_4.5.2.1', ' First words in one-line docstrings that are variables or filenames shall remain unchanged.', ' Derived', ' Shall', ' Yes [PR #185, #188]'
     ' docformatter_4.5.2.2', ' First words in one-line docstrings that are user-specified to not be capitalized shall remain unchanged.', ' Derived', ' Shall', ' Yes [PR #194]'
-    ' docformatter_4.5.3', ' Shall not place a newline after the first line of a wrapped one-line docstring.' ' Derived', ' Shall', ' Yes [PR #179]'
+    ' docformatter_4.5.3', ' Shall not place a newline after the first line of a wrapped one-line docstring.', ' Derived', ' Shall', ' Yes [PR #179]'
     ' PEP_257_5','**Multi-line docstrings:**'
     ' PEP_257_5.1',' A summary is just like a one-line docstring.',' Convention',' Shall',' Yes'
     ' docformatter_5.1.1', ' The summary line shall satisfy all the requirements of a one-line docstring.', ' Derived', ' Shall', ' Yes'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,4 +275,11 @@ commands =
     pydocstyle {toxinidir}/src/docformatter
     ruff check --select "PL" --select "F" {toxinidir}/src/docformatter
     rstcheck --report-level=1 {toxinidir}/README.rst
+
+[testenv:docs]
+description = build docformatter documentation
+allowlist_externals = make
+changedir = docs
+commands =
+    make html
 """


### PR DESCRIPTION
Closes #260

This caused Sphinx to fail to render the entire table.

After this change, the Sphinx error has gone away and the table renders:

![Screenshot 2023-08-08 at 15 31 39](https://github.com/EFord36/docformatter/assets/20516159/c5c3e5d8-1fc4-44b8-9fae-447e00280a8b)
