### PR TITLE
Handle abbreviation 'etc.' (et cetera)

### DIFF
--- a/src/docformatter/strings.py
+++ b/src/docformatter/strings.py
@@ -183,7 +183,7 @@ def split_first_sentence(text):
 
         sentence += previous_delimiter + word
 
-        if sentence.endswith(("e.g.", "i.e.", "Dr.", "Mr.", "Mrs.", "Ms.")):
+        if sentence.endswith(("e.g.", "i.e.", "etc.", "Dr.", "Mr.", "Mrs.", "Ms.")):
             # Ignore false end of sentence.
             pass
         elif sentence.endswith((".", "?", "!")):

--- a/tests/test_string_functions.py
+++ b/tests/test_string_functions.py
@@ -453,7 +453,9 @@ Try this and this and this and this and this and this and this at
     def test_split_summary_and_description_with_abbreviation(self):
         """"""
         for text in [
-            "Test e.g. now" "Test i.e. now",
+            "Test e.g. now",
+            "Test foo, bar, etc. now",
+            "Test i.e. now",
             "Test Dr. now",
             "Test Mr. now",
             "Test Mrs. now",


### PR DESCRIPTION
(Also add a missed comma in the test parametrization)