### PR TITLE
prefer new unittest.mock from the standard library

### DIFF
--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -36,9 +36,13 @@ This module contains tests for utility functions.  Utility functions are:
     - is_some_sort_of_code()
 """
 
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
 # Third Party Imports
 import pytest
-from mock import patch
 
 # docformatter Package Imports
 import docformatter


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.