### PR TITLE
🩹 Fix pre commit hook manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
           - id: end-of-file-fixer
           - id: no-commit-to-branch
           - id: trailing-whitespace
+    - repo: https://github.com/pre-commit/pre-commit
+      rev: v4.0.0
+      hooks:
+          - id: validate_manifest
     - repo: https://github.com/psf/black
       rev: '23.3.0'
       hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,10 +5,3 @@
     args: [-i]
     language: python
     types: [python]
--   id: docformatter-venv
-    name: docformatter-venv
-    description: 'Formats docstrings to follow PEP 257. Uses python3 -m venv.'
-    entry: docformatter
-    args: [-i]
-    language: python_venv
-    types: [python]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,7 @@ deps =
     charset_normalizer
     pycodestyle
     pydocstyle
-    ruff
+    ruff==0.0.269
     rstcheck
     toml
     untokenize

--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -975,4 +975,3 @@ def _field_over_url(
         if _value[1] < any_param_start:
             nonoverlapping_urls.append(_value)
     return nonoverlapping_urls
-


### PR DESCRIPTION
[pre-commit just released v4.0.0](https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0) with the breaking change that `language: python_venv` was removed.
This breaks `docformatter` hook config at parse time, even for users that don't use `docformatter-venv` (e.g. I use the "normal" `docformatter` hook).
The error is:
```py
An error has occurred: InvalidManifestError: 
==> File /home/runner/.cache/pre-commit/repocernquz3/.pre-commit-hooks.yaml
==> At Hook(id='docformatter-venv')
==> At key: language
=====> Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv'
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
```

In addition to removing `docformatter-venv` I also added the `pre-commit` built-in `validate_manifest` hook to check the hook manifest.
And for the linter CI to pass I had to add some additional fixes, since it [seems to be broken since Aug 9, 2023](https://github.com/PyCQA/docformatter/commit/5948f6dca999e5b8dae39349e08f20f65935acf6) (most likely due to a tool update but the CI logs are already gone)

### Additional info:
`language: python_venv` has been deprecated [Feb 4, 2023](https://github.com/pre-commit/pre-commit/pull/2746) and should have emitted a warning since then based on the code.
However, in my [last CI run using that passed `pre-commit` successfully](https://github.com/s-weigand/odiff-py/actions/runs/11194131736/job/31120234646) and without warning (`pre-commit==3.8.0`).
```py
...
[INFO] Installing environment for https://github.com/PyCQA/docformatter.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/absolufy-imports.
...
```
Furthermore the built-in `validate_manifest` hook in `pre-commit==3.8.0` also didn't have an issue with `language: python_venv`.
So it seems like there was no easy way to get a heads-up, except closely following the [`pre-commit`changelog](https://github.com/pre-commit/pre-commit/blob/dbccd57db0e9cf993ea909e929eea97f6e4389ea/CHANGELOG.md?plain=1#L217).

**Edit:**
Now I get why there was no warning when `pre-commit` did setup the env for `docformatter`, it's because I used the `docformatter` hook and the warning would only be shown when someone actually uses the `docformatter-venv` hook.