### PR TITLE
Update the language to meet the changes of pre-commit 4.0.0

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,5 +10,5 @@
     description: 'Formats docstrings to follow PEP 257. Uses python3 -m venv.'
     entry: docformatter
     args: [-i]
-    language: python_venv
+    language: python
     types: [python]


### PR DESCRIPTION
# Motivation
- https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0
- The `python_venv` is an alias of `python` and removed in pre-commit v4.0.0.
