### PR TITLE
fix: update README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,12 +113,6 @@ this code
         This module docstring should be dedented."""
 
 
-    def launch_rocket():
-        """Launch
-    the
-    rocket. Go colonize space."""
-
-
     def factorial(x):
         '''
 
@@ -141,7 +135,7 @@ this code
         function"""
         print_factorial(5)
         if factorial(10):
-            launch_rocket()
+            print_factorial(22)
 
 
 gets formatted into this
@@ -152,14 +146,6 @@ gets formatted into this
 
     This module docstring should be dedented.
     """
-
-
-    def launch_rocket():
-        """Launch the rocket.
-
-        Go colonize space.
-        """
-
 
     def factorial(x):
         """Return x factorial.
@@ -179,7 +165,7 @@ gets formatted into this
         """Main function."""
         print_factorial(5)
         if factorial(10):
-            launch_rocket()
+            print_factorial(22)
 
 Marketing
 =========

--- a/src/docformatter/syntax.py
+++ b/src/docformatter/syntax.py
@@ -180,6 +180,7 @@ be treated like simple text. This will ignore URLs like ``http://`` or 'ftp:`.
 """
 
 HEURISTIC_MIN_LIST_ASPECT_RATIO = 0.4
+"""The minimum aspect ratio to consider a list."""
 
 
 def description_to_list(
@@ -649,7 +650,8 @@ def is_some_sort_of_list(
     """
     split_lines = text.rstrip().splitlines()
 
-    # TODO: Find a better way of doing this.
+    # TODO: Find a better way of doing this.  Conversely, create a logger and log
+    #  potential lists for the user to decide if they are lists or not.
     # Very large number of lines but short columns probably means a list of
     # items.
     if (


### PR DESCRIPTION
The example in the README can't be produced because the 'Launch the rocket.' line gets picked up as a list is unformatted unlike in the example.  For now the README will be updated until the list-like detection code is updated.